### PR TITLE
Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-# dependecies installed by npm
 node_modules
-
-# secrets
 .env
+config.json

--- a/README.md
+++ b/README.md
@@ -54,11 +54,23 @@ You can add this `scripts` section to the `packages.json`, where we define `silv
 
 ## Add your API credentials as environmental variables
 
-You could use a new `.env` local file, or add them to an existing file in your system (e.g. `~/.bash-profile` or `~/.bashrc`)
+You could use a new `.env` local file, or add them to an existing file in your system (e.g. `~/.bash-profile`, `~/.bashrc` or `~/.zshrc`)
 
 ```
 export SF_API_CLIENT_ID=...
 export SF_API_SECRET=...
+```
+
+If you are only using one firm, you could set it up as an environmental variable. That way, you won't need to pass the `--firm <firmid>` option every time you run a command.
+
+```
+export SF_FIRM_ID=...
+```
+
+In case you need to use a different host, you can also set it up as an environmental variable. By default it would be `https://live.getsilverfin.com`.
+
+```
+export SF_HOST=...
 ```
 
 # How to use it
@@ -84,7 +96,7 @@ yarn silverfin update-reconciliation --firm <firm-id> --handle <handle>
 ## Import all existing reconciliations
 
 ```
-yarn silverfin import-all-reconciliations --firm <firm-id> --handle <handle>
+yarn silverfin import-all-reconciliations --firm <firm-id>
 ```
 
 ## Import an existing shared part
@@ -102,7 +114,7 @@ yarn silverfin update-shared-part --firm <firm-id> --handle <handle>
 ## Import all existing shared parts
 
 ```
-yarn silverfin import-all-shared-parts --firm <firm-id> --handle <handle>
+yarn silverfin import-all-shared-parts --firm <firm-id>
 ```
 
 ## Run a Liquid Test

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ A command-line tool for Silverfin template development.
 
 - Update your templates from the command-line while storing them in git repositories.
 - Run your Liquid Tests from the command-line.
+- Generate Liquid Tests from existing company files.
 
 # Setup & Basic Usage
 
 ## Prerequsites
 
-To use this CLI tool you need to first obtain a Silverfin API access_token
+To use this CLI tool you first need to register an API application within Silverfin. You will get a `client_id` and `secret`.
 
 ## Install package manager
 
@@ -27,40 +28,6 @@ Install `yarn` globally:
 npm install --global yarn
 ```
 
-## Set environment variables
-
-You can either add the environment variables locally in the file so you only need to add them once, or define them directly in the terminal. 
-
-### Local file 
-
-Add a .env file in the root directory:
-
-```
-touch .env
-```
-
-Add the following variables in  .env:
-
-```
-SF_FIRM_ID="your firm ID"
-SF_ACCESS_TOKEN="your access token"
-NODE_ENV="development"
-```
-
-### Linux / Mac terminal
-
-```
-export SF_FIRM_ID=<firm_id>
-export SF_ACCESS_TOKEN=<access_token>
-```
-
-### Windows terminal
-
-```
-set SF_FIRM_ID=<firm_id>
-set SF_ACCESS_TOKEN=<access_token>
-```
-
 ## Add sf-toolkit package
 
 Create `package.json` by running the following command and run through the prompts:
@@ -72,37 +39,78 @@ yarn init
 Install `sf-toolkit` as a dependency of your project:
 
 ```
-yarn add https://github.com/GetSilverfin/sf-toolkit.git
+yarn add https://github.com/silverfin/sf-toolkit.git
 ```
 
-## Create script shortcuts
+## Add scripts to packages.json
 
-Inside the `package.json`, add a new `scripts` block:
+You can add this `scripts` section to the `packages.json`, where we define `sf-cli` as an alias to call our CLI.
 
-```
-"scripts": {
-    "new-recon": "./node_modules/sf_toolkit/bin/cli.js new",
-    "import-recon": "./node_modules/sf_toolkit/bin/cli.js import",
-    "update-recon": "./node_modules/sf_toolkit/bin/cli.js persistReconciliationText"
-  }
-```
+  "scripts": {
+    "sf-cli": "./node_modules/sf_toolkit/bin/cli.js"
+  },
 
-You can then run these commands starting with `yarn` or `npm run`
+# How to use it
 
-## Create new template directory
+## Authorize the CLI
 
 ```
-yarn new-recon --handle <handle>
+yarn sf-cli authorize
 ```
 
-## Import existing template
+## Import an existing reconciliation
 
 ```
-yarn import-recon --handle <handle>
+yarn sf-cli import-reconciliation --firm <firm-id> --handle <handle>
 ```
 
-## Update existing template
+## Update an existing reconciliation
 
 ```
-yarn update-recon --handle <handle>
+yarn sf-cli update-reconciliation --firm <firm-id> --handle <handle>
+```
+
+## Import all existing reconciliations
+
+```
+yarn sf-cli import-all-reconciliations --firm <firm-id> --handle <handle>
+```
+
+## Import an existing shared part
+
+```
+yarn sf-cli import-shared-part --firm <firm-id> --handle <handle>
+```
+
+## Update an existing shared part
+
+```
+yarn sf-cli update-shared-part --firm <firm-id> --handle <handle>
+```
+
+## Import all existing shared parts
+
+```
+yarn sf-cli import-all-shared-parts --firm <firm-id> --handle <handle>
+```
+
+## Run a Liquid Test
+
+```
+yarn sf-cli run-test --firm <firm-id> --handle <handle>
+```
+
+## Create a Liquid Test
+
+```
+yarn sf-cli create-test --url <url>
+```
+
+## Help
+
+You can always get extra information by adding `--help`. For example:
+
+```
+yarn sf-cli --help
+yarn sf-cli import-reconciliation --help
 ```

--- a/README.md
+++ b/README.md
@@ -44,66 +44,77 @@ yarn add https://github.com/silverfin/sf-toolkit.git
 
 ## Add scripts to packages.json
 
-You can add this `scripts` section to the `packages.json`, where we define `sf-cli` as an alias to call our CLI.
+You can add this `scripts` section to the `packages.json`, where we define `silverfin` as an alias to call our CLI.
 
+```
   "scripts": {
-    "sf-cli": "./node_modules/sf_toolkit/bin/cli.js"
+    "silverfin": "node ./node_modules/sf_toolkit/bin/cli.js"
   },
+```
+
+## Add your API credentials as environmental variables
+
+You could use a new `.env` local file, or add them to an existing file in your system (e.g. `~/.bash-profile` or `~/.bashrc`)
+
+```
+export SF_API_CLIENT_ID=...
+export SF_API_SECRET=...
+```
 
 # How to use it
 
 ## Authorize the CLI
 
 ```
-yarn sf-cli authorize
+yarn silverfin authorize
 ```
 
 ## Import an existing reconciliation
 
 ```
-yarn sf-cli import-reconciliation --firm <firm-id> --handle <handle>
+yarn silverfin import-reconciliation --firm <firm-id> --handle <handle>
 ```
 
 ## Update an existing reconciliation
 
 ```
-yarn sf-cli update-reconciliation --firm <firm-id> --handle <handle>
+yarn silverfin update-reconciliation --firm <firm-id> --handle <handle>
 ```
 
 ## Import all existing reconciliations
 
 ```
-yarn sf-cli import-all-reconciliations --firm <firm-id> --handle <handle>
+yarn silverfin import-all-reconciliations --firm <firm-id> --handle <handle>
 ```
 
 ## Import an existing shared part
 
 ```
-yarn sf-cli import-shared-part --firm <firm-id> --handle <handle>
+yarn silverfin import-shared-part --firm <firm-id> --handle <handle>
 ```
 
 ## Update an existing shared part
 
 ```
-yarn sf-cli update-shared-part --firm <firm-id> --handle <handle>
+yarn silverfin update-shared-part --firm <firm-id> --handle <handle>
 ```
 
 ## Import all existing shared parts
 
 ```
-yarn sf-cli import-all-shared-parts --firm <firm-id> --handle <handle>
+yarn silverfin import-all-shared-parts --firm <firm-id> --handle <handle>
 ```
 
 ## Run a Liquid Test
 
 ```
-yarn sf-cli run-test --firm <firm-id> --handle <handle>
+yarn silverfin run-test --firm <firm-id> --handle <handle>
 ```
 
 ## Create a Liquid Test
 
 ```
-yarn sf-cli create-test --url <url>
+yarn silverfin create-test --url <url>
 ```
 
 ## Help
@@ -111,6 +122,6 @@ yarn sf-cli create-test --url <url>
 You can always get extra information by adding `--help`. For example:
 
 ```
-yarn sf-cli --help
-yarn sf-cli import-reconciliation --help
+yarn silverfin --help
+yarn silverfin import-reconciliation --help
 ```

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const prompt = require('prompt-sync')({sigint: true});
+
+class Config {
+  constructor() {
+      try {
+        this.path = path.resolve(__dirname,'./config.json');
+        const fileData = fs.readFileSync(this.path, 'utf-8');
+        this.data = JSON.parse(fileData);
+      } 
+      catch (err) {
+        console.log('File not founded. Creating new Config file.');
+        this.data = {};
+      };
+    };
+  
+  saveConfig() {
+    fs.writeFileSync(this.path, JSON.stringify(this.data), 'utf8', (err) => {
+      if (err) {
+        console.log(`Error while writing config file: ${err}`);
+      } else {
+        console.log(`Config file was written successfully`);
+      }; 
+    });
+  };
+    
+  // Store new tokens to config
+  storeNewTokens(responseTokens, firmId) {
+    if (responseTokens) {
+      this.data[firmId] = { 
+        accessToken: responseTokens.data.access_token,
+        refreshToken: responseTokens.data.refresh_token
+      };
+      this.saveConfig();
+    };   
+  };
+    
+  setClientId() {
+    this.data.clientId = prompt('Enter your API Client id: ',{echo:'*'});
+    this.saveConfig();
+  };
+    
+  setSecret() {
+    this.data.secret = prompt('Enter your API secret: ',{echo:'*'});
+    this.saveConfig();
+  };
+};
+
+const config = new Config();
+
+module.exports = {config}

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,11 +1,17 @@
 const fs = require('fs');
 const path = require('path');
-const prompt = require('prompt-sync')({sigint: true});
+
+// Location
+const homedir = require('os').homedir();
+const sfFolder = path.resolve(homedir, '.silverfin/');
+if (!fs.existsSync(sfFolder)) {
+  fs.mkdirSync(sfFolder);
+};
 
 class Config {
   constructor() {
       try {
-        this.path = path.resolve(__dirname,'./config.json');
+        this.path = path.resolve(homedir, '.silverfin/config.json');
         const fileData = fs.readFileSync(this.path, 'utf-8');
         this.data = JSON.parse(fileData);
       } 
@@ -34,16 +40,6 @@ class Config {
       };
       this.saveConfig();
     };   
-  };
-    
-  setClientId() {
-    this.data.clientId = prompt('Enter your API Client id: ',{echo:'*'});
-    this.saveConfig();
-  };
-    
-  setSecret() {
-    this.data.secret = prompt('Enter your API secret: ',{echo:'*'});
-    this.saveConfig();
   };
 };
 

--- a/api/sf_api.js
+++ b/api/sf_api.js
@@ -3,14 +3,7 @@ const axios = require('axios');
 const prompt = require('prompt-sync')({sigint: true});
 const {config} = require('./auth');
 
-// firm id and host can be changed via ENV vars
-require("dotenv").config();
-const missingVariables =  ['SF_FIRM_ID'].filter((key) => !process.env[key]);
-if (missingVariables.length && process.argv[2] !== "help") {
-  throw `Missing configuration variables: ${missingVariables}, call export ${missingVariables[0]}=... before`
-};
 const baseURL = process.env.SF_HOST || 'https://live.getsilverfin.com';
-const firmId = process.env.SF_FIRM_ID;
 
 function authorizeApp(firmId = "") {
   // Check Client ID
@@ -238,7 +231,7 @@ async function fetchTestRun(id, refreshToken = true) {
   };
  };
 
-module.exports = { 
+module.exports = {
   authorizeApp,
   fetchReconciliationTexts, 
   updateReconciliationText, 

--- a/api/sf_api.js
+++ b/api/sf_api.js
@@ -22,7 +22,12 @@ async function authorizeApp() {
   console.log(`You need to authorize your APP in the browser`);
   console.log('Insert your credentials...');
   const authCodePrompt = prompt('Enter your API authorization code: ',{echo:'*'});
-  const firmIdPrompt = prompt('Enter the firm ID: ');
+  let firmIdPrompt;
+  if (process.env.SF_FIRM_ID) {
+    firmIdPrompt = prompt(`Enter the firm ID: (leave blank to use ${process.env.SF_FIRM_ID})`, {value:process.env.SF_FIRM_ID});
+  } else {
+    firmIdPrompt = prompt('Enter the firm ID: ');
+  };
   // Get tokens
   getAccessToken(firmIdPrompt, authCodePrompt);
 };

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,6 +27,7 @@ commandsToFunctions = {
   "import_all_shared_parts": toolkit.importExistingSharedParts,
   "persist_shared_part": toolkit.persistSharedPart,
   "run_tests": toolkit.runTests,
+  "authorize": toolkit.authorize,
   "help": printHelp
 }
 
@@ -57,6 +58,9 @@ commandsDescription = {
   "run_tests": {
     "description": "Send template and test to Silverfin and waits for completion",
     "required": "--handle"
+  },
+  "authorize": {
+    "description": "Authorize the CLI by entering your Silverfin API credentials"
   },
   "help": {
     "description": `

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,9 @@
+#!/usr/bin/env node
+
 const toolkit = require('../index.js');
 const {Command} = require('commander');
 const prompt = require('prompt-sync')({sigint: true});
+const pkg = require('../package.json');
 const program = new Command();
 
 // Load firm id from ENV vars
@@ -11,9 +14,9 @@ if (process.env.SF_FIRM_ID) {
 };
 
 // Version
-program
-  .version('0.1.0');
-
+if (pkg.version){
+  program.version(pkg.version);
+};
 
 // Prompt Confirmation
 function promptConfirmation(){

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,93 +1,138 @@
-#!/usr/bin/env node
-
 const toolkit = require('../index.js');
+const {Command} = require('commander');
+const prompt = require('prompt-sync')({sigint: true});
+const program = new Command();
 
-printHelp = function () {
-  console.log("Usage:")
-  commands = Object.keys(commandsDescription)
-  maxLength = commands.sort((a, b) => b.length - a.length)[0].length
-  defaultSpaces = 4
+// Version
+program
+  .version('0.1.0');
 
-  Object.keys(commandsDescription).forEach((command) => {
-    numberOfSpaces = defaultSpaces + maxLength - command.length;
-    required_arg = commandsDescription[command]["required"]
 
-    console.log(`  ${command}${" ".repeat(numberOfSpaces)}${commandsDescription[command]["description"]}`)
-    if (required_arg) {
-      console.log(`    ${required_arg}\n`)
-    }
-  })
-}
+// Prompt Confirmation
+function promptConfirmation(){
+  const confirm = prompt('This will overwrite existin templates. Do you want to proceed? (yes/no): ')
+  if (confirm.toLocaleLowerCase() !== 'yes' && confirm.toLowerCase() !== 'y') {
+    console.log('Operation cancelled')
+    process.exit();
+  };
+  return true;
+};
 
-commandsToFunctions = {
-  "new": toolkit.createNewTemplateFolder,
-  "import": toolkit.importNewTemplateFolder,
-  "persistReconciliationText": toolkit.persistReconciliationText,
-  "import_shared_part": toolkit.importExistingSharedPartByName,
-  "import_all_shared_parts": toolkit.importExistingSharedParts,
-  "persist_shared_part": toolkit.persistSharedPart,
-  "run_tests": toolkit.runTests,
-  "authorize": toolkit.authorize,
-  "help": printHelp
-}
+// Import a single reconciliation
+program
+  .command('import-reconciliation')
+  .description('Import an existing reconciliation template')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-h, --handle <handle>', 'Mandatory. Specify the reconcilation to be used (mandatory)')
+  .option('--yes', 'Skip the prompt confirmation (optional)')
+  .action((options) => {
+    if (!options.yes) {
+      promptConfirmation();
+    };
+    firmId = options.firm;
+    toolkit.importNewTemplateFolder(options.handle);
+  });
 
-commandsDescription = {
-  "new": {
-    "description": "Generates new folder structure for a new template",
-    "required": "--handle",
-  },
-  "import": {
-    "description": "Imports existing template",
-    "required": "--handle"
-  },
-  "persistReconciliationText": {
-    "description": "Send template updates back to Silverfin",
-    "required": "--handle"
-  },
-  "import_shared_part": {
-    "description": "Imports existing shared part",
-    "required": "--handle"
-  },
-  "import_all_shared_parts": {
-    "description": "Import all existing shared parts"
-  },
-  "persist_shared_part":{
-    "description": "Send shared part updates back to Silverfin",
-    "required": "--handle"
-  },
-  "run_tests": {
-    "description": "Send template and test to Silverfin and waits for completion",
-    "required": "--handle"
-  },
-  "authorize": {
-    "description": "Authorize the CLI by entering your Silverfin API credentials"
-  },
-  "help": {
-    "description": `
-      Prints this message.
+// Update a single reconciliation
+program
+  .command('update-reconciliation')
+  .description('Update an existing reconciliation template')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-h, --handle <handle>', 'Mandatory. Specify the reconcilation to be used (mandatory)')
+  .option('--yes', 'Skip the prompt confirmation (optional)')
+  .action((options)=>{
+    if (!options.yes) {
+      promptConfirmation();
+    };
+    firmId = options.firm;
+    toolkit.persistReconciliationText(options.handle);
+  });
 
-      You need to specify SF_ACCESS_TOKEN and SF_FIRM_ID environment variables, e.g. export SF_FIRM_ID=123
-      You can also assign the SF_HOST environment variable to override the API location (to a staging or a local environment), E.g. export SF_HOST=http://localhost:3000. Default is https://live.getsilverfin.com
-    `
-  }
-}
+// Import all reconciliations
+program
+  .command('import-all-reconciliations')
+  .description('Import all reconciliations at once')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .option('--yes', 'Skip the prompt confirmation (optional)')
+  .action((options) => {
+    if (!options.yes) {
+      promptConfirmation();
+    };
+    firmId = options.firm;
+    // TO DO: Add function
+    console.log('Method not implemented yet')
+  });
 
-command = process.argv[2]
-if (!command) {
-  printHelp()
-  process.exit()
- }
+// Import a single shared part
+program
+  .command('import-shared-part')
+  .description('Import an existing shared part')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-h, --handle <handle>', 'Mandatory. Specify the shared part to be used (mandatory)')
+  .option('--yes', 'Skip the prompt confirmation (optional)')
+  .action((options) => {
+    if (!options.yes) {
+      promptConfirmation();
+    };
+    firmId = options.firm;
+    toolkit.importExistingSharedPartByName(options.handle);
+  });
 
-fun = commandsToFunctions[command]
-if (!fun) {
-  console.log("Command doesn't exist\n")
-  printHelp()
-  process.exit(1)
-}
+// Update a single shared part
+program
+  .command('update-shared-part')
+  .description('Update an existing shared part')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-h, --handle <handle>', 'Mandatory. Specify the shared part to be used (mandatory)')
+  .option('--yes', 'Skip the prompt confirmation (optional)')
+  .action((options) => {
+    if (!options.yes) {
+      promptConfirmation();
+    };
+    firmId = options.firm;
+    toolkit.persistSharedPart(options.handle);
+  });
 
-required_arg = commandsDescription[command]["required"]
-if (required_arg && (required_arg != process.argv[3] || !process.argv[4])) {
-  console.log(`${required_arg} is required`)
-} else {
-  fun(process.argv[4])
-}
+// Import all shared parts
+program
+  .command('import-all-shared-parts')
+  .description('Import all shared parts at once')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .option('--yes', 'Skip the prompt confirmation (optional)')
+  .action((options) => {
+    if (!options.yes) {
+      promptConfirmation();
+    };
+    firmId = options.firm;
+    toolkit.importExistingSharedParts();
+  });
+
+// Run Liquid Test
+program
+  .command('run-test')
+  .description('Run Liquid Tests for a reconciliation template from a YAML file')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-h, --handle <handle>', 'Mandatory. Specify the reconciliation to be used (mandatory)')
+  .action((options) => {
+    firmId = options.firm;
+    toolkit.runTests(options.handle);
+  });
+
+// Create Liquid Test 
+program
+  .command('create-test')
+  .description('Create Liquid Test (YAML file) from an existing reconciliation in a company file')
+  .requiredOption('-u, --url <url>', 'Specify the url to be used (mandatory)')
+  .action(() => {
+    // TO BE DONE
+  });
+
+// Authorize APP
+program
+  .command('authorize')
+  .description('Authorize the CLI by entering your Silverfin API credentials')
+  .action(()=>{
+    toolkit.authorize();
+  });
+
+program.parse();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,13 @@ const {Command} = require('commander');
 const prompt = require('prompt-sync')({sigint: true});
 const program = new Command();
 
+// Load firm id from ENV vars
+let firmIdDefault = undefined;
+if (process.env.SF_FIRM_ID) {
+  firmIdDefault = process.env.SF_FIRM_ID;
+  console.log(`Firm ID to be used: ${firmIdDefault}`)
+};
+
 // Version
 program
   .version('0.1.0');
@@ -10,9 +17,9 @@ program
 
 // Prompt Confirmation
 function promptConfirmation(){
-  const confirm = prompt('This will overwrite existin templates. Do you want to proceed? (yes/no): ')
+  const confirm = prompt('This will overwrite existin templates. Do you want to proceed? (yes/NO): ');
   if (confirm.toLocaleLowerCase() !== 'yes' && confirm.toLowerCase() !== 'y') {
-    console.log('Operation cancelled')
+    console.log('Operation cancelled');
     process.exit();
   };
   return true;
@@ -22,7 +29,7 @@ function promptConfirmation(){
 program
   .command('import-reconciliation')
   .description('Import an existing reconciliation template')
-  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)', firmIdDefault)
   .requiredOption('-h, --handle <handle>', 'Mandatory. Specify the reconcilation to be used (mandatory)')
   .option('--yes', 'Skip the prompt confirmation (optional)')
   .action((options) => {
@@ -37,7 +44,7 @@ program
 program
   .command('update-reconciliation')
   .description('Update an existing reconciliation template')
-  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)', firmIdDefault)
   .requiredOption('-h, --handle <handle>', 'Mandatory. Specify the reconcilation to be used (mandatory)')
   .option('--yes', 'Skip the prompt confirmation (optional)')
   .action((options)=>{
@@ -52,7 +59,7 @@ program
 program
   .command('import-all-reconciliations')
   .description('Import all reconciliations at once')
-  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)', firmIdDefault)
   .option('--yes', 'Skip the prompt confirmation (optional)')
   .action((options) => {
     if (!options.yes) {
@@ -67,7 +74,7 @@ program
 program
   .command('import-shared-part')
   .description('Import an existing shared part')
-  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)', firmIdDefault)
   .requiredOption('-h, --handle <handle>', 'Mandatory. Specify the shared part to be used (mandatory)')
   .option('--yes', 'Skip the prompt confirmation (optional)')
   .action((options) => {
@@ -82,7 +89,7 @@ program
 program
   .command('update-shared-part')
   .description('Update an existing shared part')
-  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)', firmIdDefault)
   .requiredOption('-h, --handle <handle>', 'Mandatory. Specify the shared part to be used (mandatory)')
   .option('--yes', 'Skip the prompt confirmation (optional)')
   .action((options) => {
@@ -97,7 +104,7 @@ program
 program
   .command('import-all-shared-parts')
   .description('Import all shared parts at once')
-  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)', firmIdDefault)
   .option('--yes', 'Skip the prompt confirmation (optional)')
   .action((options) => {
     if (!options.yes) {
@@ -111,7 +118,7 @@ program
 program
   .command('run-test')
   .description('Run Liquid Tests for a reconciliation template from a YAML file')
-  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)')
+  .requiredOption('-f, --firm <firm-id>', 'Specify the firm to be used (mandatory)', firmIdDefault)
   .requiredOption('-h, --handle <handle>', 'Mandatory. Specify the reconciliation to be used (mandatory)')
   .action((options) => {
     firmId = options.firm;
@@ -136,3 +143,8 @@ program
   });
 
 program.parse();
+
+// Unhandled errors while running the cli
+process.on('unhandledRejection', error => {
+  console.log(error);
+});

--- a/fs_utils.js
+++ b/fs_utils.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 createFolder = function (path) {
   if (!fs.existsSync(path)) {
@@ -20,7 +21,7 @@ createFiles = async function ({ relativePath, testFile, textParts, text }) {
   }
 
   if (!fs.existsSync(`${relativePath}/tests/README.md`)) {
-    const readmeLiquidTests = fs.readFileSync('./resources/liquid_tests/README.md')
+    const readmeLiquidTests = fs.readFileSync(path.resolve(__dirname,'./resources/liquid_tests/README.md'), 'UTF-8')
     fs.writeFileSync(`${relativePath}/tests/README.md`, readmeLiquidTests)
   }
 

--- a/fs_utils.js
+++ b/fs_utils.js
@@ -17,6 +17,11 @@ createFiles = async function ({ relativePath, testFile, textParts, text }) {
 
   fs.writeFile(`${relativePath}/tests/${testFile.name}.yml`, testFile.content, emptyCallback)
 
+  if (!fs.existsSync(`${relativePath}/tests/README.md`)) {
+    const readmeLiquidTests = fs.readFileSync('./resources/liquid_tests/README.md')
+    fs.writeFileSync(`${relativePath}/tests/README.md`, readmeLiquidTests)
+  }
+
   Object.keys(textParts).forEach((textPartName) => {
     if (textPartName) {
       fs.writeFile(`${relativePath}/text_parts/${textPartName}.liquid`, textParts[textPartName], emptyCallback)

--- a/fs_utils.js
+++ b/fs_utils.js
@@ -15,7 +15,9 @@ createFolders = function (relativePath) {
 createFiles = async function ({ relativePath, testFile, textParts, text }) {
   const emptyCallback = () => {}
 
-  fs.writeFile(`${relativePath}/tests/${testFile.name}.yml`, testFile.content, emptyCallback)
+  if (!fs.existsSync(`${relativePath}/tests/${testFile.name}.yml`)) {
+    fs.writeFile(`${relativePath}/tests/${testFile.name}.yml`, testFile.content, emptyCallback)
+  }
 
   if (!fs.existsSync(`${relativePath}/tests/README.md`)) {
     const readmeLiquidTests = fs.readFileSync('./resources/liquid_tests/README.md')

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const api = require('./api/sf_api')
 const fsUtils = require('./fs_utils')
-const fs = require('fs');
+const fs = require('fs')
 
 const RECONCILIATION_FIELDS_TO_SYNC = ["name_nl", "name_fr", "name_en", "auto_hide_formula", "text_configuration", "virtual_account_number", "reconciliation_type", "public", "allow_duplicate_reconciliations", "is_active", "tests"]
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ createNewTemplateFolder = async function (handle) {
   const relativePath = `./reconciliation_texts/${handle}`
   fsUtils.createFolder(`./reconciliation_texts`)
   fsUtils.createFolders(relativePath)
-  testFile = { name: "test", content: "" }
+  testFile = { name: handle, content: "" }
   textParts = { "part_1": "" }
   text = ""
   fsUtils.createFiles({ relativePath, testFile, textParts, text })
@@ -18,7 +18,7 @@ createNewTemplateFolder = async function (handle) {
     "text_parts": {
       "part_1": "text_parts/part_1.liquid"
     },
-    "test": "tests/test.yml",
+    "test": `tests/${handle}.yml`,
     "name_en": ""
   }
   writeConfig(relativePath, config)
@@ -34,7 +34,7 @@ importNewTemplateFolder = async function (handle) {
   fsUtils.createFolder(`./reconciliation_texts`)
   fsUtils.createFolders(relativePath)
   testFile = { 
-    name: "test", 
+    name: handle, 
     content: "# Add your Liquid Tests here"
   }
   textPartsReducer = (acc, part) => {
@@ -62,7 +62,7 @@ importNewTemplateFolder = async function (handle) {
     ...attributes,
     "text": "main.liquid",
     "text_parts": configTextParts,
-    "test": "tests/test.yml",
+    "test": `tests/${handle}.yml`,
   }
   writeConfig(relativePath, config)
 }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-const api = require('./sf_api')
+const api = require('./api/sf_api')
 const fsUtils = require('./fs_utils')
 const fs = require('fs');
 
-const RECONCILIATOIN_FIELDS_TO_SYNC = ["name_nl", "name_fr", "name_en", "auto_hide_formula", "text_configuration", "virtual_account_number", "reconciliation_type", "public", "allow_duplicate_reconciliations", "is_active", "tests"]
+const RECONCILIATION_FIELDS_TO_SYNC = ["name_nl", "name_fr", "name_en", "auto_hide_formula", "text_configuration", "virtual_account_number", "reconciliation_type", "public", "allow_duplicate_reconciliations", "is_active", "tests"]
 
 createNewTemplateFolder = async function (handle) {
   const relativePath = `./reconciliation_texts/${handle}`
@@ -45,7 +45,7 @@ importNewTemplateFolder = async function (handle) {
   textParts = reconciliationText.text_parts.reduce(textPartsReducer, {})
   fsUtils.createFiles({ relativePath, testFile, textParts, text: reconciliationText.text })
 
-  attributes = RECONCILIATOIN_FIELDS_TO_SYNC.reduce((acc, attribute) => {
+  attributes = RECONCILIATION_FIELDS_TO_SYNC.reduce((acc, attribute) => {
     acc[attribute] = reconciliationText[attribute]
     return acc
   }, {})
@@ -71,7 +71,7 @@ constructReconciliationText = function (handle) {
   const relativePath = `./reconciliation_texts/${handle}`
   const config = fsUtils.readConfig(relativePath)
 
-  const attributes = RECONCILIATOIN_FIELDS_TO_SYNC.reduce((acc, attribute) => {
+  const attributes = RECONCILIATION_FIELDS_TO_SYNC.reduce((acc, attribute) => {
     acc[attribute] = config[attribute]
     return acc
   }, {})

--- a/index.js
+++ b/index.js
@@ -194,4 +194,19 @@ runTests = async function (handle) {
     process.exit(1)
   }
 }
-module.exports = { createNewTemplateFolder, importNewTemplateFolder, constructReconciliationText, persistReconciliationText, importExistingSharedPartByName, importExistingSharedParts, persistSharedPart, runTests }
+
+authorize = function () {
+  api.authorizeApp();
+};
+
+module.exports = { 
+  createNewTemplateFolder, 
+  importNewTemplateFolder, 
+  constructReconciliationText, 
+  persistReconciliationText, 
+  importExistingSharedPartByName, 
+  importExistingSharedParts, 
+  persistSharedPart, 
+  runTests,
+  authorize
+}

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ constructReconciliationText = function (handle) {
     return acc
   }, {})
   attributes.text = fs.readFileSync(`${relativePath}/main.liquid`, 'utf-8')
-  attributes.tests = fs.readFileSync(`${relativePath}/tests/test.yml`, 'utf-8')
+  attributes.tests = fs.readFileSync(`${relativePath}/tests/${handle}.yml`, 'utf-8')
 
   const textParts = Object.keys(config.text_parts).reduce((array, name) => {
     let path = `${relativePath}/${config.text_parts[name]}`

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^0.26.1",
     "commander": "^9.4.0",
     "dotenv": "^16.0.1",
+    "open": "^8.4.0",
     "prompt-sync": "^4.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,18 @@
 {
   "name": "sf_toolkit",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Node package that let's you externally manage Silverfin templates",
   "main": "index.js",
   "license": "MIT",
   "private": false,
   "bin": "./bin/sf_toolkit.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "sf-cli": "./node_modules/sf-toolkit/bin/cli.js"
   },
   "dependencies": {
     "axios": "^0.26.1",
+    "commander": "^9.4.0",
     "dotenv": "^16.0.1",
     "prompt-sync": "^4.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "license": "MIT",
   "private": false,
-  "bin": "./bin/sf_toolkit.js",
+  "bin": "./bin/cli.js",
   "scripts": {
     "test": "jest",
-    "sf-cli": "./node_modules/sf-toolkit/bin/cli.js"
+    "silverfin": "./node_modules/sf-toolkit/bin/cli.js"
   },
   "dependencies": {
     "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   },
   "dependencies": {
     "axios": "^0.26.1",
-    "dotenv": "^16.0.1"
+    "dotenv": "^16.0.1",
+    "prompt-sync": "^4.2.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.21.0"
   }
 }

--- a/resources/liquid_tests/README.md
+++ b/resources/liquid_tests/README.md
@@ -1,0 +1,17 @@
+# Liquid Testing
+
+## [Template name]
+
+> Use this Readme file to add extra information about the Liquid Tests that can be performed
+
+### Empty state
+
+> Describe the empty state or initial state (a test were the template is usually empty)
+
+### Unit test 1: [Title]
+
+- Test 1
+- Test 2
+- ...
+
+> Add some information about what the 'Unit 1' is about and each of the test that take part of it.

--- a/sf_api.js
+++ b/sf_api.js
@@ -1,74 +1,289 @@
-const axios = require('axios')
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+const prompt = require('prompt-sync')({sigint: true});
+const configPath = path.resolve(__dirname,'./config.json');
+const Config = loadConfig();
+
+// firm id and host can be changed via ENV vars
 require("dotenv").config();
-
-const missingVariables =  ['SF_ACCESS_TOKEN', 'SF_FIRM_ID'].filter((key) => !process.env[key])
-
+const missingVariables =  ['SF_FIRM_ID'].filter((key) => !process.env[key]);
 if (missingVariables.length && process.argv[2] !== "help") {
   throw `Missing configuration variables: ${missingVariables}, call export ${missingVariables[0]}=... before`
-}
+};
+const baseURL = process.env.SF_HOST || 'https://live.getsilverfin.com';
+const firmId = process.env.SF_FIRM_ID;
 
-axios.defaults.baseURL = `${process.env.SF_HOST || 'https://live.getsilverfin.com'}/api/v4/f/${process.env.SF_FIRM_ID}`
-axios.defaults.headers.common['Authorization'] = `Bearer ${process.env.SF_ACCESS_TOKEN}`
+function loadConfig() {
+  try {
+      const fileData = fs.readFileSync(configPath, 'utf-8');
+      return JSON.parse(fileData);
+  } catch (err) {
+      console.log('File not founded. Creating new Config file.');
+      return {};
+  };
+};
 
-const fetchReconciliationTexts = function(page = 1) {
-  return axios.get(`reconciliations`, { params: { page: page, per_page: 200 } })
-}
+function saveConfig(ConfigObj) {
+  fs.writeFileSync(configPath, JSON.stringify(ConfigObj), 'utf8', (err) => {
+      if (err) {
+          console.log(`Error while writing config file: ${err}`);
+      } else {
+          console.log(`Config file was written successfully`);
+      }; 
+  });
+};
 
-const findReconciliationText = async function (handle, page = 1) {
-  return fetchReconciliationTexts(page).then((response) => {
-    reconciliations = response.data
-    if (reconciliations.length == 0) {
-      return;
-    }
+// Store new tokens to config
+function storeNewTokens(responseTokens, firmId) {
+  if (responseTokens) {
+      Config[firmId] = { 
+          accessToken: responseTokens.data.access_token,
+          refreshToken: responseTokens.data.refresh_token
+      };
+      saveConfig(Config);
+  };   
+};
 
-    reconciliationText = reconciliations.find((element) => element['handle'] === handle)
-    if (reconciliationText) {
-      return reconciliationText;
-    } else {
-      return findReconciliationText(handle, page + 1);
-    }
-  })
-}
+function setClientId() {
+  Config.clientId = prompt('Enter your API Client id: ',{echo:'*'});
+  saveConfig(Config);
+};
 
-const updateReconciliationText = function(id, attributes) {
-  return axios.post(`reconciliations/${id}`, attributes)
-}
+function setSecret() {
+  Config.secret = prompt('Enter your API secret: ',{echo:'*'});
+  saveConfig(Config);
+};
+
+function authorizeApp(firmId = "") {
+  // Check Client ID
+  if (!Config.clientId) {
+      setClientId();
+  } else {
+      console.log(`ClientId loaded from configuration file.`);
+  };
+  // Check Secret
+  if (!Config.secret) {
+      setSecret();
+  } else {
+      console.log(`Secret loaded from configuration file`);
+  };
+  const redirectUri = "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob";
+  const scope = "user%3Aprofile+user%3Aemail+webhooks+administration%3Aread+administration%3Awrite+permanent_documents%3Aread+permanent_documents%3Awrite+communication%3Aread+communication%3Awrite+financials%3Aread+financials%3Awrite+financials%3Atransactions%3Aread+financials%3Atransactions%3Awrite+links+workflows%3Aread";
+  const url = `${baseURL}/oauth/authorize?client_id=${Config.clientId}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}`;
+  console.log(`You need to authorize your App. Follow: ${url}`);
+  console.log('Insert your credentials...');
+  const authCodePrompt = prompt('Enter your API authorization code: ',{echo:'*'});
+  const firmIdPrompt = prompt('Enter the firm ID: ');
+  // Check firm id against the one entered
+  if (firmId && firmId != firmIdPrompt) {
+      throw `The firm id you entered (${firmIdPrompt}) does not match the one you are trying to use (${firmId})`;
+  };
+  // Get tokens
+  getAccessToken(Config.clientId, Config.secret, firmIdPrompt, authCodePrompt);
+};
+
+// Get Tokens for the first time
+async function getAccessToken(clientId, secret, firmId, authCode) {  
+  try {  
+    const redirectUri = "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob";
+    const grantType = "authorization_code";
+    let config = {
+      method: 'post',
+      url: `https://api.getsilverfin.com/f/${firmId}/oauth/token?client_id=${clientId}&client_secret=${secret}&redirect_uri=${redirectUri}&grant_type=${grantType}&code=${authCode}`
+    };
+    const response = await axios(config);
+    storeNewTokens(response, firmId);
+  }
+  catch (error) {
+    console.log(`Error: ${error.response.data.error_description}`);
+    process.exit();
+  };
+};
+
+// Get a new pair of tokens
+async function refreshTokens(clientId, secret, firmId, accessToken, refreshToken) {
+  try {
+    console.log(`Requesting new pair of tokens`);
+    let data = {
+      client_id: clientId,
+      client_secret: secret,
+      redirect_uri: "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob",
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      access_token: accessToken
+    };
+    const response = await axios.post(`https://api.getsilverfin.com/f/${firmId}/oauth/token`, data);
+    storeNewTokens(response, firmId);
+  }
+  catch (error) {
+    console.log(`Error refreshing: ${error.response.data.error_description}`);
+    console.log(`Try running the authentication process again`)
+    process.exit();
+  };
+};
+
+function setAxiosDefaults() {
+  if (Config.hasOwnProperty(firmId)) {
+    axios.defaults.baseURL = `${baseURL}/api/v4/f/${firmId}`
+    axios.defaults.headers.common['Authorization'] = `Bearer ${Config[String(firmId)].accessToken}`
+  } else {
+    throw `Missing authorization for firm id: ${firmId}`;
+  };
+};
+
+function responseSuccessHandler(response) {
+  console.log(`Response Status: ${response.status} (${response.statusText}) - method: ${response.config.method} - url: ${response.config.url}`);
+};
+
+async function responseErrorHandler(error, refreshToken = false, callbackFunction, callbackParameters) {
+  if (refreshToken) {
+    console.log(`Response Status: ${error.response.status} (${error.response.statusText}) - method: ${error.response.config.method} - url: ${error.response.config.url}`);
+    console.log(`Response Data: ${JSON.stringify(error.response.data.error)}`);
+    // Get a new pair of tokens
+    await refreshTokens(Config.clientId, Config.secret, firmId, Config[String(firmId)].accessToken, Config[String(firmId)].refreshToken);
+    //  Call the original function again
+    return callbackFunction(...Object.values(callbackParameters));
+  } else {
+    console.log(`Api calls failed, try to run the authorization process again`);
+    process.exit();
+  };
+};
+
+async function fetchReconciliationTexts(page = 1, refreshToken = true) {
+  setAxiosDefaults();
+  try {
+    const response = await axios.get(`reconciliations`, { params: { page: page, per_page: 200 } })
+    responseSuccessHandler(response);
+    return response;
+  } 
+  catch (error) {
+    const callbackParameters = {page: page, refreshToken: false};
+    const response = await responseErrorHandler(error, refreshToken, fetchReconciliationTexts, callbackParameters);
+    return response;
+  };
+};
+
+async function findReconciliationText(handle, page = 1) {
+  const response = await fetchReconciliationTexts(page);
+  const reconciliations = response.data;
+  // No data
+  if (reconciliations.length == 0) {
+    console.log(`Reconciliation ${handle} not found`);
+    return;
+  };
+  const reconciliationText = reconciliations.find((element) => element['handle'] === handle);
+  if (reconciliationText) {
+    return reconciliationText;
+  } else {
+    return findReconciliationText(handle, page + 1);
+  };
+};
+
+async function updateReconciliationText(id, attributes, refreshToken = true) {
+  setAxiosDefaults();
+  try {
+    const response = await axios.post(`reconciliations/${id}`, attributes);
+    responseSuccessHandler(response);
+    return response;
+  } 
+  catch (error) {
+    const callbackParameters = {id:id, attributes:attributes, refreshToken: false};
+    responseErrorHandler(error, refreshToken, updateReconciliationText, callbackParameters); 
+  };
+};
 
 
-const fetchSharedParts = function(page = 1) {
-  return axios.get(`shared_parts`, { params: { page: page, per_page: 200 }})
-}
+async function fetchSharedParts(page = 1, refreshToken = true) {
+  setAxiosDefaults();
+  try {
+    const response = await axios.get(`shared_parts`, { params: { page: page, per_page: 200 }});
+    responseSuccessHandler(response);
+    return response;
+  }
+  catch (error) {
+    const callbackParameters = {page:page , refreshToken: false};
+    responseErrorHandler(error, refreshToken, fetchSharedParts, callbackParameters);
+  };
+};
 
-const fetchSharedPartById = function(id) {
-  return axios.get(`shared_parts/${id}`)
-}
+async function fetchSharedPartById(id, refreshToken = true) {
+  setAxiosDefaults();
+  try {
+    const response = await axios.get(`shared_parts/${id}`);
+    responseSuccessHandler(response);
+    return response;
+  } 
+  catch (error) {
+    const callbackParameters = {id:id, refreshToken: false};
+    responseErrorHandler(error, refreshToken, fetchSharedPartById, callbackParameters);
+  };
+};
 
-const findSharedPart = async function (name, page = 1) {
-  return fetchSharedParts(page).then((response) => {
-    sharedParts = response.data
-    if (sharedParts.lenght == 0) {
-      return;
-    }
+async function findSharedPart(name, page = 1) {
+  const response = await fetchSharedParts(page);
+  const sharedParts = response.data;
+  // No data
+  if (sharedParts.lenght == 0) {
+    console.log(`Shared part ${name} not found`);
+    return;
+  }
+  const sharedPart = sharedParts.find((element) => element['name'] === name);
+  if (sharedPart) {
+    return sharedPart;
+  } else {
+    return findSharedPart(name, page + 1);
+  }
+};
 
-    sharedPart = sharedParts.find((element) => element['name'] === name)
-    if (sharedPart) {
-      return sharedPart;
-    } else {
-      return findSharedPart(name, page + 1);
-    }
-  })
-}
+async function updateSharedPart(id, attributes, refreshToken = true) {
+  setAxiosDefaults();
+  try {
+    const response = await axios.post(`shared_parts/${id}`, attributes);
+    responseSuccessHandler(response);
+    return response;
+  }
+  catch (error) {
+    const callbackParameters = {id:id, attributes:attributes, refreshToken: false};
+    responseErrorHandler(error, refreshToken, updateSharedPart, callbackParameters);
+  };
+};
 
-const updateSharedPart = function(id, attributes) {
-  return axios.post(`shared_parts/${id}`, attributes)
-}
+async function createTestRun(attributes, refreshToken = true) {
+  setAxiosDefaults();
+  try {
+    const response = await axios.post('reconciliations/test', attributes);
+    responseSuccessHandler(response);
+    return response;
+  }
+  catch (error) {
+    const callbackParameters = {attributes:attributes, refreshToken: false};
+    responseErrorHandler(error, refreshToken, createTestRun, callbackParameters);
+  };
+};
 
-const createTestRun = function(attributes) {
-  return axios.post('reconciliations/test', attributes)
-}
+async function fetchTestRun(id, refreshToken = true) {
+  setAxiosDefaults();
+  try {
+    const response = await axios.get(`reconciliations/test_runs/${id}`);
+    responseSuccessHandler(response);
+    return response;
+  }
+  catch (error) {
+    const callbackParameters = {id:id, refreshToken: false};
+    responseErrorHandler(error, refreshToken, fetchTestRun, callbackParameters);
+  };
+ };
 
-const fetchTestRun = function(id) {
-  return axios.get(`reconciliations/test_runs/${id}`)
- }
-
-module.exports = { fetchReconciliationTexts, updateReconciliationText, findReconciliationText, fetchSharedParts, fetchSharedPartById, findSharedPart, updateSharedPart, fetchTestRun, createTestRun }
+module.exports = { 
+  authorizeApp,
+  fetchReconciliationTexts, 
+  updateReconciliationText, 
+  findReconciliationText, 
+  fetchSharedParts, 
+  fetchSharedPartById, 
+  findSharedPart, 
+  updateSharedPart, 
+  fetchTestRun, 
+  createTestRun 
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,784 @@
 # yarn lockfile v1
 
 
-"axios@^0.26.1":
-  "integrity" "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA=="
-  "resolved" "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz"
-  "version" "0.26.1"
+"@eslint/eslintrc@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz#29f92c30bb3e771e4a2048c95fa6855392dfac4f"
+  integrity sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==
   dependencies:
-    "follow-redirects" "^1.14.8"
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.3.2"
+    globals "^13.15.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
+    strip-json-comments "^3.1.1"
 
-"dotenv@^16.0.1":
-  "integrity" "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
-  "resolved" "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz"
-  "version" "16.0.1"
+"@humanwhocodes/config-array@^0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.4.tgz#01e7366e57d2ad104feea63e72248f22015c520c"
+  integrity sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.1"
+    debug "^4.1.1"
+    minimatch "^3.0.4"
 
-"follow-redirects@^1.14.8":
-  "integrity" "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
-  "resolved" "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz"
-  "version" "1.14.9"
+"@humanwhocodes/gitignore-to-minimatch@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz#316b0a63b91c10e53f242efb4ace5c3b34e8728d"
+  integrity sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==
+
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@nodelib/fs.scandir@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.5"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.5"
+    fastq "^1.6.0"
+
+acorn-jsx@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
+
+ajv@^6.10.0, ajv@^6.12.4:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+braces@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
+
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+cross-spawn@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+debug@^4.1.1, debug@^4.3.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+deep-is@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
+
+dotenv@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz"
+  integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+eslint-scope@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
+  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
+eslint-visitor-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
+
+eslint@^8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.21.0.tgz#1940a68d7e0573cef6f50037addee295ff9be9ef"
+  integrity sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==
+  dependencies:
+    "@eslint/eslintrc" "^1.3.0"
+    "@humanwhocodes/config-array" "^0.10.4"
+    "@humanwhocodes/gitignore-to-minimatch" "^1.0.2"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.1.1"
+    eslint-utils "^3.0.0"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.3"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^6.0.1"
+    globals "^13.15.0"
+    globby "^11.1.0"
+    grapheme-splitter "^1.0.4"
+    ignore "^5.2.0"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.2"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    regexpp "^3.2.0"
+    strip-ansi "^6.0.1"
+    strip-json-comments "^3.1.0"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^9.3.2, espree@^9.3.3:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.3.tgz#2dd37c4162bb05f433ad3c1a52ddf8a49dc08e9d"
+  integrity sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.3.0"
+
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
+
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-glob@^3.2.9:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-levenshtein@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fastq@^1.6.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
+  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
+  dependencies:
+    reusify "^1.0.4"
+
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
+
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
+flatted@^3.1.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.6.tgz#022e9218c637f9f3fc9c35ab9c9193f05add60b2"
+  integrity sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==
+
+follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
+
+glob-parent@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
+glob@^7.1.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+globals@^13.15.0:
+  version "13.17.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz#902eb1e680a41da93945adbdcb5a9f361ba69bd4"
+  integrity sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==
+  dependencies:
+    type-fest "^0.20.2"
+
+globby@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^3.0.0"
+
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+ignore@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
+import-fresh@^3.0.0, import-fresh@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+merge2@^1.3.0, merge2@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromatch@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
+
+minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
+
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
+
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
+
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prompt-sync@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/prompt-sync/-/prompt-sync-4.2.0.tgz#0198f73c5b70e3b03e4b9033a50540a7c9a1d7f4"
+  integrity sha512-BuEzzc5zptP5LsgV5MZETjDaKSWfchl5U9Luiu8SKp7iZWD5tZalOxvNcZRwv+d2phNFr8xlbxmFNcRKfJOzJw==
+  dependencies:
+    strip-ansi "^5.0.0"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+queue-microtask@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+regexpp@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
+run-parallel@^1.1.9:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+  dependencies:
+    queue-microtask "^1.2.2"
+
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+strip-ansi@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+uri-js@^4.2.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
+
+v8-compile-cache@^2.0.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
+word-wrap@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,6 +187,11 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -483,6 +488,11 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -499,6 +509,13 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -578,6 +595,15 @@ once@^1.3.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+open@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 optionator@^0.9.1:
   version "0.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,6 +156,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
+  integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
First Draft of an authentication module. To use it:
- You will need to set first your firm id as an env var: `export SF_FIRM_ID=...`
- You can run the authorisation process: `.node_modules/sf-toolkit/bin/cli.js authorize`
- You should be able now to run any of the existing commands
 
Some comments:
- Credentials are now saved in a json file, still to decide where to store them.
- My idea is to make the firm id a required argument in the CLI, that way we could potentially handle different firms where the user has access to.
- Moved sf_api to a separate directory.