### PR TITLE
Firm parameter

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -15,10 +15,11 @@ class Config {
       const fileData = fs.readFileSync(this.path, "utf-8");
       this.data = JSON.parse(fileData);
     } catch (err) {
-      this.data = {};
+      this.data = { defaultFirmIDs: {} };
     }
   }
 
+  // Write file
   saveConfig() {
     fs.writeFileSync(
       this.path,
@@ -35,6 +36,7 @@ class Config {
   }
 
   // Store new tokens to config
+  // { firmId: {accessToken: string, refreshToken: string}}
   storeNewTokens(responseTokens, firmId) {
     if (responseTokens) {
       this.data[firmId] = {
@@ -44,8 +46,35 @@ class Config {
       this.saveConfig();
     }
   }
+
+  // Set default firm id
+  setFirmId(firmId) {
+    this.checkDefaultFirmsObject();
+    const currentDirectory = path.basename(process.cwd());
+    this.data.defaultFirmIDs[currentDirectory] = firmId;
+    this.saveConfig();
+  }
+
+  // Get default firm id
+  getFirmId() {
+    this.checkDefaultFirmsObject();
+    const currentDirectory = path.basename(process.cwd());
+    if (this.data.defaultFirmIDs.hasOwnProperty(currentDirectory)) {
+      return this.data.defaultFirmIDs[currentDirectory];
+    } else {
+      return null;
+    }
+  }
+
+  // Create DefaultFirmIDs (for legacy compatibility of existing files)
+  checkDefaultFirmsObject() {
+    if (!this.data.hasOwnProperty("defaultFirmIDs")) {
+      this.data.defaultFirmIDs = {};
+    }
+  }
 }
 
+// Iniatiate Object
 const config = new Config();
 
 module.exports = { config };

--- a/api/auth.js
+++ b/api/auth.js
@@ -84,7 +84,7 @@ class Config {
   }
 }
 
-// Iniatiate Object
+// Initiate Object
 const config = new Config();
 
 module.exports = { config };

--- a/api/auth.js
+++ b/api/auth.js
@@ -47,6 +47,16 @@ class Config {
     }
   }
 
+  // Get Access Token
+  getTokens(firmId) {
+    this.checkDefaultFirmsObject();
+    if (this.data.hasOwnProperty(firmId)) {
+      return this.data[firmId];
+    } else {
+      return null;
+    }
+  }
+
   // Set default firm id
   setFirmId(firmId) {
     this.checkDefaultFirmsObject();

--- a/api/sf_api.js
+++ b/api/sf_api.js
@@ -20,17 +20,20 @@ if (missingVariables.length) {
   process.exit(1);
 }
 
-async function authorizeApp() {
+async function authorizeApp(firmId = undefined) {
   try {
+    console.log(
+      `Note: if you need to exit this process you can press "Ctrl/Cmmd + C"`
+    );
     const redirectUri = "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob";
     const scope =
       "user%3Aprofile+user%3Aemail+webhooks+administration%3Aread+administration%3Awrite+permanent_documents%3Aread+permanent_documents%3Awrite+communication%3Aread+communication%3Awrite+financials%3Aread+financials%3Awrite+financials%3Atransactions%3Aread+financials%3Atransactions%3Awrite+links+workflows%3Aread";
 
     let firmIdPrompt;
-    if (process.env.SF_FIRM_ID) {
+    if (firmId) {
       firmIdPrompt = prompt(
-        `Enter the firm ID: (leave blank to use ${process.env.SF_FIRM_ID})`,
-        { value: process.env.SF_FIRM_ID }
+        `Enter the firm ID: (leave blank to use ${firmId})`,
+        { value: firmId }
       );
     } else {
       firmIdPrompt = prompt("Enter the firm ID: ");

--- a/api/sf_api.js
+++ b/api/sf_api.js
@@ -109,7 +109,7 @@ async function refreshTokens(firmId, accessToken, refreshToken) {
   }
 }
 
-function setAxiosDefaults() {
+function setAxiosDefaults(firmId) {
   if (config.data.hasOwnProperty(firmId)) {
     axios.defaults.baseURL = `${baseURL}/api/v4/f/${firmId}`;
     axios.defaults.headers.common["Authorization"] = `Bearer ${
@@ -128,6 +128,7 @@ function responseSuccessHandler(response) {
 }
 
 async function responseErrorHandler(
+  firmId,
   error,
   refreshToken = false,
   callbackFunction,
@@ -179,8 +180,8 @@ async function responseErrorHandler(
   throw error;
 }
 
-async function fetchReconciliationTexts(page = 1, refreshToken = true) {
-  setAxiosDefaults();
+async function fetchReconciliationTexts(firmId, page = 1, refreshToken = true) {
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(`reconciliations`, {
       params: { page: page, per_page: 2000 },
@@ -188,8 +189,13 @@ async function fetchReconciliationTexts(page = 1, refreshToken = true) {
     responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = { page: page, refreshToken: false };
+    const callbackParameters = {
+      firmId: firmId,
+      page: page,
+      refreshToken: false,
+    };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       fetchReconciliationTexts,
@@ -199,8 +205,8 @@ async function fetchReconciliationTexts(page = 1, refreshToken = true) {
   }
 }
 
-async function findReconciliationText(handle, page = 1) {
-  const response = await fetchReconciliationTexts(page);
+async function findReconciliationText(firmId, handle, page = 1) {
+  const response = await fetchReconciliationTexts(firmId, page);
   const reconciliations = response.data;
   // No data
   if (reconciliations.length == 0) {
@@ -218,23 +224,33 @@ async function findReconciliationText(handle, page = 1) {
       }
     }
   } else {
-    return findReconciliationText(handle, page + 1);
+    return findReconciliationText(firmId, handle, page + 1);
   }
 }
 
-async function updateReconciliationText(id, attributes, refreshToken = true) {
-  setAxiosDefaults();
+async function updateReconciliationText(
+  firmId,
+  reconciliationId,
+  attributes,
+  refreshToken = true
+) {
+  setAxiosDefaults(firmId);
   try {
-    const response = await axios.post(`reconciliations/${id}`, attributes);
+    const response = await axios.post(
+      `reconciliations/${reconciliationId}`,
+      attributes
+    );
     responseSuccessHandler(response);
     return response;
   } catch (error) {
     const callbackParameters = {
-      id: id,
+      firmId: firmId,
+      reconciliationId: reconciliationId,
       attributes: attributes,
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       updateReconciliationText,
@@ -245,12 +261,13 @@ async function updateReconciliationText(id, attributes, refreshToken = true) {
 }
 
 async function getReconciliationDetails(
+  firmId,
   companyId,
   periodId,
   reconciliationId,
   refreshToken = true
 ) {
-  setAxiosDefaults();
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(
       `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}`
@@ -259,12 +276,14 @@ async function getReconciliationDetails(
     return response;
   } catch (error) {
     const callbackParameters = {
+      firmId: firmId,
       companyId: companyId,
       periodId: periodId,
       reconciliationId: reconciliationId,
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       getReconciliationDetails,
@@ -275,13 +294,14 @@ async function getReconciliationDetails(
 }
 
 async function getReconciliationCustom(
+  firmId,
   companyId,
   periodId,
   reconciliationId,
   page = 1,
   refreshToken = true
 ) {
-  setAxiosDefaults();
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(
       `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/custom`,
@@ -291,6 +311,7 @@ async function getReconciliationCustom(
     return response;
   } catch (error) {
     const callbackParameters = {
+      firmId: firmId,
       companyId: companyId,
       periodId: periodId,
       reconciliationId: reconciliationId,
@@ -298,6 +319,7 @@ async function getReconciliationCustom(
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       getReconciliationCustom,
@@ -308,12 +330,13 @@ async function getReconciliationCustom(
 }
 
 async function getReconciliationResults(
+  firmId,
   companyId,
   periodId,
   reconciliationId,
   refreshToken = true
 ) {
-  setAxiosDefaults();
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(
       `/companies/${companyId}/periods/${periodId}/reconciliations/${reconciliationId}/results`
@@ -322,12 +345,14 @@ async function getReconciliationResults(
     return response;
   } catch (error) {
     const callbackParameters = {
+      firmId: firmId,
       companyId: companyId,
       periodId: periodId,
       reconciliationId: reconciliationId,
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       getReconciliationResults,
@@ -337,8 +362,8 @@ async function getReconciliationResults(
   }
 }
 
-async function fetchSharedParts(page = 1, refreshToken = true) {
-  setAxiosDefaults();
+async function fetchSharedParts(firmId, page = 1, refreshToken = true) {
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(`shared_parts`, {
       params: { page: page, per_page: 2000 },
@@ -346,8 +371,13 @@ async function fetchSharedParts(page = 1, refreshToken = true) {
     responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = { page: page, refreshToken: false };
+    const callbackParameters = {
+      firmId: firmId,
+      page: page,
+      refreshToken: false,
+    };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       fetchSharedParts,
@@ -357,15 +387,20 @@ async function fetchSharedParts(page = 1, refreshToken = true) {
   }
 }
 
-async function fetchSharedPartById(id, refreshToken = true) {
-  setAxiosDefaults();
+async function fetchSharedPartById(firmId, sharedPartId, refreshToken = true) {
+  setAxiosDefaults(firmId);
   try {
-    const response = await axios.get(`shared_parts/${id}`);
+    const response = await axios.get(`shared_parts/${sharedPartId}`);
     responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = { id: id, refreshToken: false };
+    const callbackParameters = {
+      firmId: firmId,
+      sharedPartId: sharedPartId,
+      refreshToken: false,
+    };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       fetchSharedPartById,
@@ -375,35 +410,47 @@ async function fetchSharedPartById(id, refreshToken = true) {
   }
 }
 
-async function findSharedPart(name, page = 1) {
-  const response = await fetchSharedParts(page);
+async function findSharedPart(firmId, sharedPartName, page = 1) {
+  const response = await fetchSharedParts(firmId, page);
   const sharedParts = response.data;
   // No data
   if (sharedParts.length == 0) {
-    console.log(`Shared part ${name} not found`);
+    console.log(`Shared part ${sharedPartName} not found`);
     return;
   }
-  const sharedPart = sharedParts.find((element) => element["name"] === name);
+  const sharedPart = sharedParts.find(
+    (element) => element["name"] === sharedPartName
+  );
   if (sharedPart) {
     return sharedPart;
   } else {
-    return findSharedPart(name, page + 1);
+    return findSharedPart(firmId, sharedPartName, page + 1);
   }
 }
 
-async function updateSharedPart(id, attributes, refreshToken = true) {
-  setAxiosDefaults();
+async function updateSharedPart(
+  firmId,
+  sharedPartId,
+  attributes,
+  refreshToken = true
+) {
+  setAxiosDefaults(firmId);
   try {
-    const response = await axios.post(`shared_parts/${id}`, attributes);
+    const response = await axios.post(
+      `shared_parts/${sharedPartId}`,
+      attributes
+    );
     responseSuccessHandler(response);
     return response;
   } catch (error) {
     const callbackParameters = {
-      id: id,
+      firmId: firmId,
+      sharedPartId: sharedPartId,
       attributes: attributes,
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       updateSharedPart,
@@ -414,11 +461,12 @@ async function updateSharedPart(id, attributes, refreshToken = true) {
 }
 
 async function addSharedPart(
+  firmId,
   sharedPartId,
   reconciliationId,
   refreshToken = true
 ) {
-  setAxiosDefaults();
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.post(
       `reconciliations/${reconciliationId}/shared_parts/${sharedPartId}`
@@ -427,11 +475,13 @@ async function addSharedPart(
     return response;
   } catch (error) {
     const callbackParameters = {
+      firmId: firmId,
       sharedPartId: sharedPartId,
       reconciliationId: reconciliationId,
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       updateSharedPart,
@@ -442,11 +492,12 @@ async function addSharedPart(
 }
 
 async function removeSharedPart(
+  firmId,
   sharedPartId,
   reconciliationId,
   refreshToken = true
 ) {
-  setAxiosDefaults();
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.delete(
       `reconciliations/${reconciliationId}/shared_parts/${sharedPartId}`
@@ -455,11 +506,13 @@ async function removeSharedPart(
     return response;
   } catch (error) {
     const callbackParameters = {
+      firmId: firmId,
       sharedPartId: sharedPartId,
       reconciliationId: reconciliationId,
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       updateSharedPart,
@@ -469,14 +522,19 @@ async function removeSharedPart(
   }
 }
 
-async function createTestRun(attributes, refreshToken = true) {
-  setAxiosDefaults();
+async function createTestRun(firmId, attributes, refreshToken = true) {
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.post("reconciliations/test", attributes);
     return response;
   } catch (error) {
-    const callbackParameters = { attributes: attributes, refreshToken: false };
+    const callbackParameters = {
+      firmId: firmId,
+      attributes: attributes,
+      refreshToken: false,
+    };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       createTestRun,
@@ -486,14 +544,19 @@ async function createTestRun(attributes, refreshToken = true) {
   }
 }
 
-async function fetchTestRun(id, refreshToken = true) {
-  setAxiosDefaults();
+async function fetchTestRun(firmId, testId, refreshToken = true) {
+  setAxiosDefaults(firmId);
   try {
-    const response = await axios.get(`reconciliations/test_runs/${id}`);
+    const response = await axios.get(`reconciliations/test_runs/${testId}`);
     return response;
   } catch (error) {
-    const callbackParameters = { id: id, refreshToken: false };
+    const callbackParameters = {
+      firmId: firmId,
+      testId: testId,
+      refreshToken: false,
+    };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       fetchTestRun,
@@ -503,8 +566,8 @@ async function fetchTestRun(id, refreshToken = true) {
   }
 }
 
-async function getPeriods(companyId, page = 1, refreshToken = true) {
-  setAxiosDefaults();
+async function getPeriods(firmId, companyId, page = 1, refreshToken = true) {
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(`/companies/${companyId}/periods`, {
       params: { page: page, per_page: 2000 },
@@ -513,11 +576,13 @@ async function getPeriods(companyId, page = 1, refreshToken = true) {
     return response;
   } catch (error) {
     const callbackParameters = {
+      firmId: firmId,
       companyId: companyId,
       page: page,
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       getPeriods,
@@ -531,15 +596,20 @@ function findPeriod(periodId, periodsArray) {
   return periodsArray.find((period) => period.id == periodId);
 }
 
-async function getCompanyDrop(companyId, refreshToken = true) {
-  setAxiosDefaults();
+async function getCompanyDrop(firmId, companyId, refreshToken = true) {
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(`/companies/${companyId}`);
     responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = { companyId: companyId, refreshToken: false };
+    const callbackParameters = {
+      firmId: firmId,
+      companyId: companyId,
+      refreshToken: false,
+    };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       getCompanyDrop,
@@ -549,15 +619,20 @@ async function getCompanyDrop(companyId, refreshToken = true) {
   }
 }
 
-async function getCompanyCustom(companyId, refreshToken = true) {
-  setAxiosDefaults();
+async function getCompanyCustom(firmId, companyId, refreshToken = true) {
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(`/companies/${companyId}/custom`);
     responseSuccessHandler(response);
     return response;
   } catch (error) {
-    const callbackParameters = { companyId: companyId, refreshToken: false };
+    const callbackParameters = {
+      firmId: firmId,
+      companyId: companyId,
+      refreshToken: false,
+    };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       getCompanyCustom,
@@ -567,8 +642,8 @@ async function getCompanyCustom(companyId, refreshToken = true) {
   }
 }
 
-async function getWorkflows(companyId, periodId, refreshToken = true) {
-  setAxiosDefaults();
+async function getWorkflows(firmId, companyId, periodId, refreshToken = true) {
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(
       `/companies/${companyId}/periods/${periodId}/workflows`
@@ -577,11 +652,13 @@ async function getWorkflows(companyId, periodId, refreshToken = true) {
     return response;
   } catch (error) {
     const callbackParameters = {
+      firmId: firmId,
       companyId: companyId,
       periodId: periodId,
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       getWorkflows,
@@ -592,13 +669,14 @@ async function getWorkflows(companyId, periodId, refreshToken = true) {
 }
 
 async function getWorkflowInformation(
+  firmId,
   companyId,
   periodId,
   workflowId,
   page = 1,
   refreshToken = true
 ) {
-  setAxiosDefaults();
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(
       `/companies/${companyId}/periods/${periodId}/workflows/${workflowId}/reconciliations`,
@@ -608,6 +686,7 @@ async function getWorkflowInformation(
     return response;
   } catch (error) {
     const callbackParameters = {
+      firmId: firmId,
       companyId: companyId,
       periodId: periodId,
       workflowId: workflowId,
@@ -615,6 +694,7 @@ async function getWorkflowInformation(
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       getWorkflowInformation,
@@ -625,6 +705,7 @@ async function getWorkflowInformation(
 }
 
 async function findReconciliationInWorkflow(
+  firmId,
   reconciliationHandle,
   companyId,
   periodId,
@@ -632,6 +713,7 @@ async function findReconciliationInWorkflow(
   page = 1
 ) {
   const response = await getWorkflowInformation(
+    firmId,
     companyId,
     periodId,
     workflowId,
@@ -652,6 +734,7 @@ async function findReconciliationInWorkflow(
     return reconciliationText;
   } else {
     return findReconciliationInWorkflow(
+      firmId,
       reconciliationHandle,
       companyId,
       periodId,
@@ -662,15 +745,17 @@ async function findReconciliationInWorkflow(
 }
 
 async function findReconciliationInWorkflows(
+  firmId,
   reconciliationHandle,
   companyId,
   periodId
 ) {
   // Get data from all workflows
-  const responseWorkflows = await getWorkflows(companyId, periodId);
+  const responseWorkflows = await getWorkflows(firmId, companyId, periodId);
   // Check in each workflow
   for (workflow of responseWorkflows.data) {
     let reconciliationInformation = await findReconciliationInWorkflow(
+      firmId,
       reconciliationHandle,
       companyId,
       periodId,
@@ -688,12 +773,13 @@ async function findReconciliationInWorkflows(
 }
 
 async function getAccountDetails(
+  firmId,
   companyId,
   periodId,
   accountId,
   refreshToken = true
 ) {
-  setAxiosDefaults();
+  setAxiosDefaults(firmId);
   try {
     const response = await axios.get(
       `companies/${companyId}/periods/${periodId}/accounts/${accountId}`
@@ -702,12 +788,14 @@ async function getAccountDetails(
     return response;
   } catch (error) {
     const callbackParameters = {
+      firmId: firmId,
       companyId: companyId,
       periodId: periodId,
       accountId: accountId,
       refreshToken: false,
     };
     const response = await responseErrorHandler(
+      firmId,
       error,
       refreshToken,
       getAccountDetails,

--- a/api/sf_api.js
+++ b/api/sf_api.js
@@ -113,11 +113,12 @@ async function refreshTokens(firmId, accessToken, refreshToken) {
 }
 
 function setAxiosDefaults(firmId) {
-  if (config.data.hasOwnProperty(firmId)) {
+  const firmCredentials = config.getTokens(firmId);
+  if (firmCredentials) {
     axios.defaults.baseURL = `${baseURL}/api/v4/f/${firmId}`;
-    axios.defaults.headers.common["Authorization"] = `Bearer ${
-      config.data[String(firmId)].accessToken
-    }`;
+    axios.defaults.headers.common[
+      "Authorization"
+    ] = `Bearer ${firmCredentials.accessToken}`;
   } else {
     console.log(`Missing authorization for firm id: ${firmId}`);
     process.exit(1);

--- a/api/sf_api.js
+++ b/api/sf_api.js
@@ -32,7 +32,7 @@ async function authorizeApp(firmId = undefined) {
     let firmIdPrompt;
     if (firmId) {
       firmIdPrompt = prompt(
-        `Enter the firm ID: (leave blank to use ${firmId})`,
+        `Enter the firm ID (leave blank to use ${firmId}): `,
         { value: firmId }
       );
     } else {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -64,8 +64,7 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    firmId = options.firm;
-    toolkit.importExistingReconciliationByHandle(options.handle);
+    toolkit.importExistingReconciliationByHandle(options.firm, options.handle);
   });
 
 // Update a single reconciliation
@@ -87,8 +86,7 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    firmId = options.firm;
-    toolkit.persistReconciliationText(options.handle);
+    toolkit.persistReconciliationText(options.firm, options.handle);
   });
 
 // Import all reconciliations
@@ -106,8 +104,7 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    firmId = options.firm;
-    toolkit.importExistingReconciliations();
+    toolkit.importExistingReconciliations(options.firm);
   });
 
 // Import a single shared part
@@ -129,8 +126,7 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    firmId = options.firm;
-    toolkit.importExistingSharedPartByName(options.handle);
+    toolkit.importExistingSharedPartByName(options.firm, options.handle);
   });
 
 // Update a single shared part
@@ -152,8 +148,7 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    firmId = options.firm;
-    toolkit.persistSharedPart(options.handle);
+    toolkit.persistSharedPart(options.firm, options.handle);
   });
 
 // Import all shared parts
@@ -171,8 +166,7 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    firmId = options.firm;
-    toolkit.importExistingSharedParts();
+    toolkit.importExistingSharedParts(options.firm);
   });
 
 // Update shared parts used in a reconciliation
@@ -194,8 +188,7 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    firmId = options.firm;
-    toolkit.refreshSharedPartsUsed(options.handle);
+    toolkit.refreshSharedPartsUsed(options.firm, options.handle);
   });
 
 // Add shared part to reconciliation
@@ -221,8 +214,11 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    firmId = options.firm;
-    toolkit.addSharedPartToReconciliation(options.sharedPart, options.handle);
+    toolkit.addSharedPartToReconciliation(
+      options.firm,
+      options.sharedPart,
+      options.handle
+    );
   });
 
 // Remove shared part to reconciliation
@@ -248,8 +244,8 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    firmId = options.firm;
     toolkit.removeSharedPartFromReconciliation(
+      options.firm,
       options.sharedPart,
       options.handle
     );
@@ -272,8 +268,7 @@ program
   )
   .action((options) => {
     checkDefaultFirm(options.firm);
-    firmId = options.firm;
-    toolkit.runTests(options.handle);
+    toolkit.runTests(options.firm, options.handle);
   });
 
 // Create Liquid Test

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -65,7 +65,7 @@ program
     // Check that only one of both options it's selected
     if ((!options.handle && !options.all) || (options.handle && options.all)) {
       console.log(
-        "Import shared part: you have to use either --handle or --all option"
+        "Import reconciliation: you have to use either --handle or --all option"
       );
       process.exit(1);
     }
@@ -121,7 +121,7 @@ program
     // Check that only one of both options it's selected
     if ((!options.name && !options.all) || (options.name && options.all)) {
       console.log(
-        "Import reconciliation: you have to use either --name or --all option"
+        "Import shared part: you have to use either --name or --all option"
       );
       process.exit(1);
     }
@@ -285,7 +285,7 @@ program
 program
   .command("authorize")
   .description("Authorize the CLI by entering your Silverfin API credentials")
-  .action((options) => {
+  .action(() => {
     toolkit.authorize(firmIdDefault);
   });
 
@@ -310,6 +310,15 @@ program
   )
   .option("-g, --get-firm", "Check if there is any firm id already stored")
   .action((options) => {
+    if (
+      (!options.setFirm && !options.getFirm) ||
+      (options.setFirm && options.getFirm)
+    ) {
+      console.log(
+        "Configuration: You have to use either --get-firm or --set-firm option"
+      );
+      process.exit(1);
+    }
     if (options.setFirm) {
       toolkit.setDefaultFirmID(options.setFirm);
     }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -158,28 +158,6 @@ program
     toolkit.persistSharedPart(options.firm, options.handle);
   });
 
-// Update shared parts used in a reconciliation
-program
-  .command("shared-parts-used")
-  .description("Update the list of shared used for a specific reconciliation")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used (mandatory)",
-    firmIdDefault
-  )
-  .requiredOption(
-    "-h, --handle <handle>",
-    "Specify the reconciliation to be used (mandatory)"
-  )
-  .option("--yes", "Skip the prompt confirmation (optional)")
-  .action((options) => {
-    if (!options.yes) {
-      promptConfirmation();
-    }
-    checkDefaultFirm(options.firm);
-    toolkit.refreshSharedPartsUsed(options.firm, options.handle);
-  });
-
 // Add shared part to reconciliation
 program
   .command("add-shared-part")
@@ -238,6 +216,28 @@ program
       options.sharedPart,
       options.handle
     );
+  });
+
+// Update shared parts used in a reconciliation
+program
+  .command("shared-parts-used")
+  .description("Update the list of shared used for a specific reconciliation")
+  .requiredOption(
+    "-f, --firm <firm-id>",
+    "Specify the firm to be used (mandatory)",
+    firmIdDefault
+  )
+  .requiredOption(
+    "-h, --handle <handle>",
+    "Specify the reconciliation to be used (mandatory)"
+  )
+  .option("--yes", "Skip the prompt confirmation (optional)")
+  .action((options) => {
+    if (!options.yes) {
+      promptConfirmation();
+    }
+    checkDefaultFirm(options.firm);
+    toolkit.refreshSharedPartsUsed(options.firm, options.handle);
   });
 
 // Run Liquid Test

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -300,8 +300,8 @@ program
 program
   .command("authorize")
   .description("Authorize the CLI by entering your Silverfin API credentials")
-  .action(() => {
-    toolkit.authorize();
+  .action((options) => {
+    toolkit.authorize(firmIdDefault);
   });
 
 // Repositories Statistics
@@ -313,7 +313,8 @@ program
   )
   .action((options) => {
     stats.generateStatsOverview(options.since);
-    
+  });
+
 // Set/Get FIRM ID
 program
   .command("config")

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,9 +8,13 @@ const prompt = require("prompt-sync")({ sigint: true });
 const pkg = require("../package.json");
 const program = new Command();
 
-// Load firm id from ENV vars
+// Load default firm id from Config Object or ENV
 let firmIdDefault = undefined;
-if (process.env.SF_FIRM_ID) {
+let firmStoredConfig = toolkit.getDefaultFirmID();
+if (firmStoredConfig) {
+  firmIdDefault = firmStoredConfig;
+}
+if (!firmIdDefault && process.env.SF_FIRM_ID) {
   firmIdDefault = process.env.SF_FIRM_ID;
 }
 function checkDefaultFirm(firmUsed) {
@@ -324,7 +328,12 @@ program
       toolkit.setDefaultFirmID(options.setFirm);
     }
     if (options.getFirm) {
-      toolkit.getDefaultFirmID();
+      const storedFirmId = toolkit.getDefaultFirmID();
+      if (storedFirmId) {
+        console.log(`Firm id previously stored: ${storedFirmId}`);
+      } else {
+        console.log("There is no firm id previously stored");
+      }
     }
   });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -49,26 +49,38 @@ function promptConfirmation() {
   return true;
 }
 
-// Import a single reconciliation
+// Import reconciliations
 program
   .command("import-reconciliation")
-  .description("Import an existing reconciliation template")
+  .description("Import reconciliation templates")
   .requiredOption(
     "-f, --firm <firm-id>",
-    "Specify the firm to be used (mandatory)",
+    "Specify the firm to be used",
     firmIdDefault
   )
-  .requiredOption(
-    "-h, --handle <handle>",
-    "Specify the reconcilation to be used (mandatory)"
-  )
+  .option("-h, --handle <handle>", "Import a specific reconciliation")
+  .option("-a, --all", "Import all reconciliations")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
+    // Check that only one of both options it's selected
+    if ((!options.handle && !options.all) || (options.handle && options.all)) {
+      console.log(
+        "Import shared part: you have to use either --handle or --all option"
+      );
+      process.exit(1);
+    }
     if (!options.yes) {
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    toolkit.importExistingReconciliationByHandle(options.firm, options.handle);
+    if (options.handle) {
+      toolkit.importExistingReconciliationByHandle(
+        options.firm,
+        options.handle
+      );
+    } else if (options.all) {
+      toolkit.importExistingReconciliations(options.firm);
+    }
   });
 
 // Update a single reconciliation
@@ -93,44 +105,35 @@ program
     toolkit.persistReconciliationText(options.firm, options.handle);
   });
 
-// Import all reconciliations
-program
-  .command("import-all-reconciliations")
-  .description("Import all reconciliations at once")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used (mandatory)",
-    firmIdDefault
-  )
-  .option("--yes", "Skip the prompt confirmation (optional)")
-  .action((options) => {
-    if (!options.yes) {
-      promptConfirmation();
-    }
-    checkDefaultFirm(options.firm);
-    toolkit.importExistingReconciliations(options.firm);
-  });
-
 // Import a single shared part
 program
   .command("import-shared-part")
   .description("Import an existing shared part")
   .requiredOption(
     "-f, --firm <firm-id>",
-    "Specify the firm to be used (mandatory)",
+    "Specify the firm to be used",
     firmIdDefault
   )
-  .requiredOption(
-    "-n, --name <handle>",
-    "Specify the shared part to be used (mandatory)"
-  )
+  .option("-n, --name <name>", "Import a specific shared part")
+  .option("-a, --all", "Import all shared parts")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
+    // Check that only one of both options it's selected
+    if ((!options.name && !options.all) || (options.name && options.all)) {
+      console.log(
+        "Import reconciliation: you have to use either --name or --all option"
+      );
+      process.exit(1);
+    }
     if (!options.yes) {
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    toolkit.importExistingSharedPartByName(options.firm, options.name);
+    if (options.name) {
+      toolkit.importExistingSharedPartByName(options.firm, options.name);
+    } else if (options.all) {
+      toolkit.importExistingSharedParts(options.firm);
+    }
   });
 
 // Update a single shared part
@@ -153,24 +156,6 @@ program
     }
     checkDefaultFirm(options.firm);
     toolkit.persistSharedPart(options.firm, options.handle);
-  });
-
-// Import all shared parts
-program
-  .command("import-all-shared-parts")
-  .description("Import all shared parts at once")
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used (mandatory)",
-    firmIdDefault
-  )
-  .option("--yes", "Skip the prompt confirmation (optional)")
-  .action((options) => {
-    if (!options.yes) {
-      promptConfirmation();
-    }
-    checkDefaultFirm(options.firm);
-    toolkit.importExistingSharedParts(options.firm);
   });
 
 // Update shared parts used in a reconciliation

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -121,7 +121,7 @@ program
     firmIdDefault
   )
   .requiredOption(
-    "-h, --handle <handle>",
+    "-n, --name <handle>",
     "Specify the shared part to be used (mandatory)"
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
@@ -130,7 +130,7 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    toolkit.importExistingSharedPartByName(options.firm, options.handle);
+    toolkit.importExistingSharedPartByName(options.firm, options.name);
   });
 
 // Update a single shared part

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -309,6 +309,23 @@ program
   )
   .action((options) => {
     stats.generateStatsOverview(options.since);
+    
+// Set/Get FIRM ID
+program
+  .command("config")
+  .description("Configuration options")
+  .option(
+    "-s, --set-firm <firmId>",
+    "Store a firm id to use it as default (setting a firm id will overwrite any existing data)"
+  )
+  .option("-g, --get-firm", "Check if there is any firm id already stored")
+  .action((options) => {
+    if (options.setFirm) {
+      toolkit.setDefaultFirmID(options.setFirm);
+    }
+    if (options.getFirm) {
+      toolkit.getDefaultFirmID();
+    }
   });
 
 program.parse();

--- a/fs_utils.js
+++ b/fs_utils.js
@@ -119,6 +119,9 @@ function getTemplatePaths(relativePath) {
     throw "relativePath should be shared_parts or reconciliation_texts";
   }
   let templatesArray = [];
+  if (!fs.existsSync(`./${relativePath}`)) {
+    return templatesArray;
+  }
   let allTemplates = fs.readdirSync(`./${relativePath}`);
   for (templateDir of allTemplates) {
     let templatePath = `./${relativePath}/${templateDir}`;

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const { spinner } = require("./resources/spinner");
 const chalk = require("chalk");
 const pkg = require("./package.json");
+const { config } = require("./api/auth");
 
 const RECONCILIATION_FIELDS_TO_SYNC = [
   "id",
@@ -613,6 +614,16 @@ function authorize() {
   SF.authorizeApp();
 }
 
+function setDefaultFirmID(firmId) {
+  config.setFirmId(firmId);
+  console.log(`Set firm id to: ${firmId}`);
+}
+
+function getDefaultFirmID() {
+  const firmId = config.getFirmId();
+  return firmId;
+}
+
 module.exports = {
   importExistingReconciliationByHandle,
   importExistingReconciliations,
@@ -626,4 +637,6 @@ module.exports = {
   runTests,
   authorize,
   uncaughtErrors,
+  setDefaultFirmID,
+  getDefaultFirmID,
 };

--- a/index.js
+++ b/index.js
@@ -433,7 +433,6 @@ async function runTests(firmId, handle) {
       const response = await SF.fetchTestRun(firmId, testRunId);
       testRun = response.data;
     }
-    spinner.stop();
 
     // Possible status: started, completed, test_error, internal_error
     if (testRun.status === "internal_error") {
@@ -451,9 +450,6 @@ async function runTests(firmId, handle) {
       if (testRun.result.length === 0) {
         console.log(chalk.green("ALL TESTS HAVE PASSED"));
       } else {
-        // Test run successfully but return errors
-        spinner.spin("Processing test results..");
-        spinner.stop();
         const formattedTests = [];
 
         testRun.result.map((test) => {
@@ -512,7 +508,6 @@ async function runTests(firmId, handle) {
           }
         });
 
-        spinner.clear();
         console.log("");
 
         console.error(
@@ -602,6 +597,8 @@ async function runTests(firmId, handle) {
         });
       }
     }
+
+    spinner.clear();
     // Always return the response from Silverfin
     // We use this in the VS-Code extension to process results
     return testRun;

--- a/index.js
+++ b/index.js
@@ -108,16 +108,17 @@ function storeImportedReconciliation(reconciliationText) {
   fsUtils.writeConfig(relativePath, configContent);
 }
 
-async function importExistingReconciliationByHandle(handle) {
-  reconciliationText = await SF.findReconciliationText(handle);
+async function importExistingReconciliationByHandle(firmId, handle) {
+  reconciliationText = await SF.findReconciliationText(firmId, handle);
   if (!reconciliationText) {
     throw `${handle} wasn't found`;
   }
   storeImportedReconciliation(reconciliationText);
 }
 
-async function importExistingReconciliations(page = 1) {
-  const response = await SF.fetchReconciliationTexts(page);
+// Import all reconciliations
+async function importExistingReconciliations(firmId, page = 1) {
+  const response = await SF.fetchReconciliationTexts(firmId, page);
   const reconciliationsArray = response.data;
   if (reconciliationsArray.length == 0) {
     if (page == 1) {
@@ -128,7 +129,7 @@ async function importExistingReconciliations(page = 1) {
   reconciliationsArray.forEach(async (reconciliation) => {
     storeImportedReconciliation(reconciliation);
   });
-  importExistingReconciliations(page + 1);
+  importExistingReconciliations(firmId, page + 1);
 }
 
 function constructReconciliationText(handle) {
@@ -157,7 +158,7 @@ function constructReconciliationText(handle) {
   return attributes;
 }
 
-async function persistReconciliationText(handle) {
+async function persistReconciliationText(firmId, handle) {
   try {
     const relativePath = `./reconciliation_texts/${handle}`;
     const config = fsUtils.readConfig(relativePath);
@@ -166,13 +167,14 @@ async function persistReconciliationText(handle) {
       reconciliationTextId = config.id;
       console.log("Loaded from config");
     } else {
-      reconciliationTextId = { ...(await SF.findReconciliationText(handle)) }
-        .id;
+      reconciliationTextId = {
+        ...(await SF.findReconciliationText(firmId, handle)),
+      }.id;
     }
     if (!reconciliationTextId) {
       throw "Reconciliation not found";
     }
-    SF.updateReconciliationText(reconciliationTextId, {
+    SF.updateReconciliationText(firmId, reconciliationTextId, {
       ...constructReconciliationText(handle),
       version_comment: "Update published using the API",
     });
@@ -181,8 +183,8 @@ async function persistReconciliationText(handle) {
   }
 }
 
-async function importExistingSharedPartById(id) {
-  const sharedPart = await SF.fetchSharedPartById(id);
+async function importExistingSharedPartById(firmId, id) {
+  const sharedPart = await SF.fetchSharedPartById(firmId, id);
 
   if (!sharedPart) {
     throw `Shared part ${id} wasn't found.`;
@@ -209,16 +211,16 @@ async function importExistingSharedPartById(id) {
   fsUtils.writeConfig(relativePath, config);
 }
 
-async function importExistingSharedPartByName(name) {
-  const sharedPartByName = await SF.findSharedPart(name);
+async function importExistingSharedPartByName(firmId, name) {
+  const sharedPartByName = await SF.findSharedPart(firmId, name);
   if (!sharedPartByName) {
     throw `Shared part with name ${name} wasn't found.`;
   }
-  importExistingSharedPartById(sharedPartByName.id);
+  importExistingSharedPartById(firmId, sharedPartByName.id);
 }
 
-async function importExistingSharedParts(page = 1) {
-  const response = await SF.fetchSharedParts(page);
+async function importExistingSharedParts(firmId, page = 1) {
+  const response = await SF.fetchSharedParts(firmId, page);
   const sharedParts = response.data;
   if (sharedParts.length == 0) {
     if (page == 1) {
@@ -227,12 +229,12 @@ async function importExistingSharedParts(page = 1) {
     return;
   }
   sharedParts.forEach(async (sharedPart) => {
-    await importExistingSharedPartById(sharedPart.id);
+    await importExistingSharedPartById(firmId, sharedPart.id);
   });
-  importExistingSharedParts(page + 1);
+  importExistingSharedParts(firmId, page + 1);
 }
 
-async function persistSharedPart(name) {
+async function persistSharedPart(firmId, name) {
   try {
     const relativePath = `./shared_parts/${name}`;
     const config = fsUtils.readConfig(relativePath);
@@ -241,7 +243,7 @@ async function persistSharedPart(name) {
       `${relativePath}/${name}.liquid`,
       "utf-8"
     );
-    SF.updateSharedPart(config.id, {
+    SF.updateSharedPart(firmId, config.id, {
       ...attributes,
       version_comment: "Testing Cli",
     });
@@ -286,6 +288,7 @@ function refreshSharedPartsUsed(handle) {
 }
 
 async function addSharedPartToReconciliation(
+  firmId,
   sharedPartHandle,
   reconciliationHandle
 ) {
@@ -298,6 +301,7 @@ async function addSharedPartToReconciliation(
     const configSharedPart = fsUtils.readConfig(relativePathSharedPart);
 
     const response = await SF.addSharedPart(
+      firmId,
       configSharedPart.id,
       configReconciliation.id
     );
@@ -336,6 +340,7 @@ async function addSharedPartToReconciliation(
 }
 
 async function removeSharedPartFromReconciliation(
+  firmId,
   sharedPartHandle,
   reconciliationHandle
 ) {
@@ -348,6 +353,7 @@ async function removeSharedPartFromReconciliation(
     const configSharedPart = fsUtils.readConfig(relativePathSharedPart);
 
     const response = await SF.removeSharedPart(
+      firmId,
       configSharedPart.id,
       configReconciliation.id
     );
@@ -377,7 +383,7 @@ async function removeSharedPartFromReconciliation(
   }
 }
 
-async function runTests(handle) {
+async function runTests(firmId, handle) {
   try {
     const relativePath = `./reconciliation_texts/${handle}`;
     const config = fsUtils.readConfig(relativePath);
@@ -406,7 +412,7 @@ async function runTests(handle) {
       tests: testContent,
     };
 
-    const testRunResponse = await SF.createTestRun(testParams);
+    const testRunResponse = await SF.createTestRun(firmId, testParams);
     const testRunId = testRunResponse.data;
 
     let testRun = { status: "started" };
@@ -417,7 +423,7 @@ async function runTests(handle) {
       await new Promise((resolve) => {
         setTimeout(resolve, pollingDelay);
       });
-      const response = await SF.fetchTestRun(testRunId);
+      const response = await SF.fetchTestRun(firmId, testRunId);
       testRun = response.data;
     }
     spinner.stop();

--- a/index.js
+++ b/index.js
@@ -412,6 +412,12 @@ async function runTests(firmId, handle) {
       tests: testContent,
     };
 
+    // Empty YAML check
+    if (testContent.split("\n").length <= 1) {
+      console.log(`${handle}: there are no tests stored in the YAML file`);
+      process.exit(1);
+    }
+
     const testRunResponse = await SF.createTestRun(firmId, testParams);
     const testRunId = testRunResponse.data;
 

--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ async function importExistingSharedPartById(firmId, id) {
     sharedPart.data.text
   );
 
-  config = {
+  let config = {
     id: sharedPart.data.id,
     name: sharedPart.data.name,
     text: "main.liquid",

--- a/index.js
+++ b/index.js
@@ -610,8 +610,8 @@ async function runTests(firmId, handle) {
   }
 }
 
-function authorize() {
-  SF.authorizeApp();
+function authorize(firmId = undefined) {
+  SF.authorizeApp(firmId);
 }
 
 function setDefaultFirmID(firmId) {

--- a/liquid_test_generator/generator.js
+++ b/liquid_test_generator/generator.js
@@ -21,6 +21,7 @@ async function testGenerator(url) {
 
   // Get Reconciliation Details
   const responseDetails = await SF.getReconciliationDetails(
+    parameters.firmId,
     parameters.companyId,
     parameters.ledgerId,
     parameters.reconciliationId
@@ -30,6 +31,7 @@ async function testGenerator(url) {
   // Get Workflow Information
   const starredStatus = {
     ...SF.findReconciliationInWorkflow(
+      parameters.firmId,
       reconciliationHandle,
       parameters.companyId,
       parameters.ledgerId,
@@ -38,7 +40,10 @@ async function testGenerator(url) {
   }.starred;
 
   // Get period data
-  const responsePeriods = await SF.getPeriods(parameters.companyId);
+  const responsePeriods = await SF.getPeriods(
+    parameters.firmId,
+    parameters.companyId
+  );
   const currentPeriodData = SF.findPeriod(
     parameters.ledgerId,
     responsePeriods.data
@@ -72,6 +77,7 @@ async function testGenerator(url) {
 
   // Get all the text properties (Customs from current template)
   const responseCustom = await SF.getReconciliationCustom(
+    parameters.firmId,
     parameters.companyId,
     parameters.ledgerId,
     parameters.reconciliationId
@@ -86,6 +92,7 @@ async function testGenerator(url) {
 
   // Get all the results generated in current template
   const responseResults = await SF.getReconciliationResults(
+    parameters.firmId,
     parameters.companyId,
     parameters.ledgerId,
     parameters.reconciliationId
@@ -94,6 +101,7 @@ async function testGenerator(url) {
 
   // Get the code of the template
   const reconciliationCode = await SF.findReconciliationText(
+    parameters.firmId,
     reconciliationHandle
   );
 
@@ -119,10 +127,16 @@ async function testGenerator(url) {
   if (sharedPartsUsed && sharedPartsUsed.length != 0) {
     for (sharedPartName of sharedPartsUsed) {
       // Look for shared part id
-      let sharedPartResponse = await SF.findSharedPart(sharedPartName);
+      let sharedPartResponse = await SF.findSharedPart(
+        parameters.firmId,
+        sharedPartName
+      );
       let sharedPartId = sharedPartResponse.id;
       // Get shared part details
-      let sharedPartDetails = await SF.fetchSharedPartById(sharedPartId);
+      let sharedPartDetails = await SF.fetchSharedPartById(
+        parameters.firmId,
+        sharedPartId
+      );
       // Look for nested shared parts (in that case, add them to this same loop)
       let nestedSharedParts = Utils.lookForSharedPartsInLiquid(
         sharedPartDetails.data
@@ -155,6 +169,7 @@ async function testGenerator(url) {
       try {
         // Find reconciliation in Workflow to get id (depdeency template can be in a different Workflow)
         let reconciliation = await SF.findReconciliationInWorkflows(
+          parameters.firmId,
           handle,
           parameters.companyId,
           parameters.ledgerId
@@ -162,6 +177,7 @@ async function testGenerator(url) {
         if (reconciliation) {
           // Fetch results
           let reconciliationResults = await SF.getReconciliationResults(
+            parameters.firmId,
             parameters.companyId,
             parameters.ledgerId,
             reconciliation.id
@@ -206,6 +222,7 @@ async function testGenerator(url) {
       try {
         // Find reconciliation in Workflow to get id (depdeency template can be in a different Workflow)
         let reconciliation = await SF.findReconciliationInWorkflows(
+          parameters.firmId,
           handle,
           parameters.companyId,
           parameters.ledgerId
@@ -213,6 +230,7 @@ async function testGenerator(url) {
         if (reconciliation) {
           // Fetch test properties
           let reconciliationCustomResponse = await SF.getReconciliationCustom(
+            parameters.firmId,
             parameters.companyId,
             parameters.ledgerId,
             reconciliation.id
@@ -262,7 +280,10 @@ async function testGenerator(url) {
 
   // Get Company Data - company drop
   if (companyObj.standardDropElements.length !== 0) {
-    const responseCompanyDrop = await SF.getCompanyDrop(parameters.companyId);
+    const responseCompanyDrop = await SF.getCompanyDrop(
+      parameters.firmId,
+      parameters.companyId
+    );
     const companyData = responseCompanyDrop.data; // { foo: bar, baz: bat ... }
 
     for (drop of companyObj.standardDropElements) {
@@ -277,6 +298,7 @@ async function testGenerator(url) {
   // Get Company Data - custom drop
   if (companyObj.customDropElements.length !== 0) {
     const responseCompanyCustom = await SF.getCompanyCustom(
+      parameters.firmId,
       parameters.companyId
     );
     const companyCustom = responseCompanyCustom.data; // [ { namespace: foo, key: bar, value: baz }... ]
@@ -309,6 +331,7 @@ async function testGenerator(url) {
       // Current Period
       try {
         let accountResponse = await SF.getAccountDetails(
+          parameters.firmId,
           parameters.companyId,
           parameters.ledgerId,
           accountId

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf_toolkit",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/resources/spinner.js
+++ b/resources/spinner.js
@@ -40,12 +40,10 @@ class Spinner {
   }
 
   clear() {
+    this.running = false;
     readline.clearLine(process.stdout);
     readline.cursorTo(process.stdout, 0);
-  }
-
-  stop() {
-    this.running = false;
+    std.write("\x1B[?25h");
   }
 }
 


### PR DESCRIPTION
- Add firm id as parameter to every function. This will allow us to use the repository not only as a CLI, but also to include it as a dependency in our VS Code Extension
- Store a 'default' firm id in the Config Object and create setter/getter functions for it.
- We keep the firm id as env variable for legacy compatibility. But I think this should be remove to simplify the flow (only CLI argument or Config stored)

@Woetfin after we implement this changes, I really think that we should look into implementing the changes into the way we store the templates id in the `config.json` file to allow storing multiple firms. If we don't do it now, it will be a bigger breaking change in the future once people start using this tool. I have already prepared most of the code so I could align it with the latest changes and create a new PR for it