### PR TITLE
New CLI command: import reconciliation by id

### DIFF
--- a/api/sf_api.js
+++ b/api/sf_api.js
@@ -232,6 +232,25 @@ async function findReconciliationText(firmId, handle, page = 1) {
   }
 }
 
+async function findReconciliationTextById(firmId, reconciliationId, page = 1) {
+  const response = await fetchReconciliationTexts(firmId, page);
+  const reconciliations = response.data;
+  // No data
+  if (reconciliations.length == 0) {
+    console.log(`Reconciliation ${reconciliationId} not found`);
+    return;
+  }
+  let reconciliationText = reconciliations.filter(
+    (element) => element["id"] === Number(reconciliationId)
+  )[0];
+  // Only return reconciliations were liquid code is not hidden
+  if (reconciliationText && reconciliationText.hasOwnProperty("text")) {
+    return reconciliationText;
+  } else {
+    return findReconciliationText(firmId, reconciliationId, page + 1);
+  }
+}
+
 async function updateReconciliationText(
   firmId,
   reconciliationId,
@@ -814,6 +833,7 @@ module.exports = {
   fetchReconciliationTexts,
   updateReconciliationText,
   findReconciliationText,
+  findReconciliationTextById,
   getReconciliationDetails,
   getReconciliationCustom,
   getReconciliationResults,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -58,14 +58,21 @@ program
     "Specify the firm to be used",
     firmIdDefault
   )
-  .option("-h, --handle <handle>", "Import a specific reconciliation")
+  .option("-h, --handle <handle>", "Import a specific reconciliation by handle")
+  .option("-i, --id <id>", "Import a specific reconciliation by id")
   .option("-a, --all", "Import all reconciliations")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    // Check that only one of both options it's selected
-    if ((!options.handle && !options.all) || (options.handle && options.all)) {
+    // Check that only one of the options it's selected
+    const uniqueParameters = ["handle", "id", "all"];
+    const optionsToCheck = Object.keys(options).filter((element) => {
+      if (uniqueParameters.includes(element)) {
+        return true;
+      }
+    });
+    if (optionsToCheck.length !== 1) {
       console.log(
-        "Import reconciliation: you have to use either --handle or --all option"
+        "Import reconciliation: you have to use either --handle, --id or --all option"
       );
       process.exit(1);
     }
@@ -78,6 +85,8 @@ program
         options.firm,
         options.handle
       );
+    } else if (options.id) {
+      toolkit.importExistingReconciliationById(options.firm, options.id);
     } else if (options.all) {
       toolkit.importExistingReconciliations(options.firm);
     }

--- a/index.js
+++ b/index.js
@@ -110,9 +110,20 @@ function storeImportedReconciliation(reconciliationText) {
 }
 
 async function importExistingReconciliationByHandle(firmId, handle) {
-  reconciliationText = await SF.findReconciliationText(firmId, handle);
+  const reconciliationText = await SF.findReconciliationText(firmId, handle);
   if (!reconciliationText) {
     throw `${handle} wasn't found`;
+  }
+  storeImportedReconciliation(reconciliationText);
+}
+
+async function importExistingReconciliationById(firmId, reconciliationId) {
+  const reconciliationText = await SF.findReconciliationTextById(
+    firmId,
+    reconciliationId
+  );
+  if (!reconciliationText) {
+    throw `${reconciliationId} wasn't found`;
   }
   storeImportedReconciliation(reconciliationText);
 }
@@ -623,6 +634,7 @@ function getDefaultFirmID() {
 
 module.exports = {
   importExistingReconciliationByHandle,
+  importExistingReconciliationById,
   importExistingReconciliations,
   persistReconciliationText,
   importExistingSharedPartByName,


### PR DESCRIPTION
Add the option to import reconciliations with the ID instead of the handle
`silverfin import-reconciliation --id <id>`