### PR TITLE
Fix: exit liquid test run process when an error occurred

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,11 +450,15 @@ async function runTests(firmId, handle) {
       console.log(
         "Internal error. Try to run the test again or contact support if the issue persists."
       );
+      spinner.clear();
+      process.exit(1);
     }
 
     if (testRun.status === "test_error") {
       console.log("Ran into an error an couldn't complete test run");
       console.log(chalk.red(testRun.error_message));
+      spinner.clear();
+      process.exit(1);
     }
 
     if (testRun.status === "completed") {


### PR DESCRIPTION
* Exit running liquid test process when an error occurred
* Clean spinner
* Disable keyboard when spinner is running (still to be added)