### PR TITLE
Store multiple firm IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules
 .env
 config.json
+
+# Template directories
 reconciliation_texts
 shared_parts
 account_templates

--- a/api/auth.js
+++ b/api/auth.js
@@ -68,11 +68,10 @@ class Config {
   getFirmId() {
     this.checkDefaultFirmsObject();
     const currentDirectory = path.basename(process.cwd());
-    if (this.data.defaultFirmIDs.hasOwnProperty(currentDirectory)) {
-      return this.data.defaultFirmIDs[currentDirectory];
-    } else {
+    if (!this.data.defaultFirmIDs.hasOwnProperty(currentDirectory)) {
       return null;
     }
+    return this.data.defaultFirmIDs[currentDirectory];
   }
 
   // Create DefaultFirmIDs (for legacy compatibility of existing files)

--- a/api/auth.js
+++ b/api/auth.js
@@ -50,11 +50,10 @@ class Config {
   // Get Access Token
   getTokens(firmId) {
     this.checkDefaultFirmsObject();
-    if (this.data.hasOwnProperty(firmId)) {
-      return this.data[firmId];
-    } else {
+    if (!this.data.hasOwnProperty(firmId)) {
       return null;
     }
+    return this.data[firmId];
   }
 
   // Set default firm id

--- a/api/sf_api.js
+++ b/api/sf_api.js
@@ -156,7 +156,7 @@ async function responseErrorHandler(
       `Response Error (401): ${JSON.stringify(error.response.data.error)}`
     );
     if (refreshToken) {
-      let firmTokens = config.getTokens(firmId);
+      const firmTokens = config.getTokens(firmId);
       // Get a new pair of tokens
       await refreshTokens(
         firmId,

--- a/api/sf_api.js
+++ b/api/sf_api.js
@@ -156,11 +156,12 @@ async function responseErrorHandler(
       `Response Error (401): ${JSON.stringify(error.response.data.error)}`
     );
     if (refreshToken) {
+      let firmTokens = config.getTokens(firmId);
       // Get a new pair of tokens
       await refreshTokens(
         firmId,
-        config.data[String(firmId)].accessToken,
-        config.data[String(firmId)].refreshToken
+        firmTokens.accessToken,
+        firmTokens.refreshToken
       );
       //  Call the original function again
       return callbackFunction(...Object.values(callbackParameters));
@@ -241,9 +242,9 @@ async function findReconciliationTextById(firmId, reconciliationId, page = 1) {
     console.log(`Reconciliation ${reconciliationId} not found`);
     return;
   }
-  let reconciliationText = reconciliations.filter(
+  const reconciliationText = reconciliations.find(
     (element) => element["id"] === Number(reconciliationId)
-  )[0];
+  );
   // Only return reconciliations were liquid code is not hidden
   if (reconciliationText && reconciliationText.hasOwnProperty("text")) {
     return reconciliationText;
@@ -478,6 +479,27 @@ async function updateSharedPart(
       error,
       refreshToken,
       updateSharedPart,
+      callbackParameters
+    );
+    return response;
+  }
+}
+
+async function createSharedPart(firmId, attributes, refreshToken = true) {
+  setAxiosDefaults(firmId);
+  try {
+    const response = await axios.post(`shared_parts`, attributes);
+    responseSuccessHandler(response);
+    return response;
+  } catch (error) {
+    const callbackParameters = {
+      attributes: attributes,
+      refreshToken: false,
+    };
+    const response = await responseErrorHandler(
+      error,
+      refreshToken,
+      createSharedPart,
       callbackParameters
     );
     return response;
@@ -842,6 +864,7 @@ module.exports = {
   fetchSharedPartById,
   findSharedPart,
   updateSharedPart,
+  createSharedPart,
   addSharedPart,
   removeSharedPart,
   fetchTestRun,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -146,17 +146,17 @@ program
     "Specify the firm to be used",
     firmIdDefault
   )
-  .option("-n, --name <name>", "Import a specific shared part")
+  .option("-s, --shared-part <name>", "Import a specific shared part")
   .option("-a, --all", "Import all shared parts")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    checkUniqueOption(["name", "all"], options);
+    checkUniqueOption(["sharedPart", "all"], options);
     if (!options.yes) {
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    if (options.name) {
-      toolkit.importExistingSharedPartByName(options.firm, options.name);
+    if (options.sharedPart) {
+      toolkit.importExistingSharedPartByName(options.firm, options.sharedPart);
     } else if (options.all) {
       toolkit.importExistingSharedParts(options.firm);
     }
@@ -172,7 +172,7 @@ program
     firmIdDefault
   )
   .requiredOption(
-    "-n, --name <name>",
+    "-s, --shared-part <name>",
     "Specify the shared part to be used (mandatory)"
   )
   .option("--yes", "Skip the prompt confirmation (optional)")
@@ -181,7 +181,7 @@ program
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    toolkit.persistSharedPart(options.firm, options.name);
+    toolkit.persistSharedPart(options.firm, options.sharedPart);
   });
 
 // Create new shared parts
@@ -193,32 +193,16 @@ program
     "Specify the firm to be used",
     firmIdDefault
   )
-  .option("-n, --name <name>", "Specify the shared part to be used")
+  .option("-s, --shared-part <name>", "Specify the shared part to be used")
   .option(
     "-a, --all",
     "Try to create all the shared parts stored in the repository"
   )
-  .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    // Check that only one of the options it's selected
-    const uniqueParameters = ["name", "all"];
-    const optionsToCheck = Object.keys(options).filter((element) => {
-      if (uniqueParameters.includes(element)) {
-        return true;
-      }
-    });
-    if (optionsToCheck.length !== 1) {
-      console.log(
-        "Create shared part: you have to use either --name or --all option"
-      );
-      process.exit(1);
-    }
-    if (!options.yes) {
-      promptConfirmation();
-    }
+    checkUniqueOption(["sharedPart", "all"], options);
     checkDefaultFirm(options.firm);
-    if (options.name) {
-      toolkit.newSharedPart(options.firm, options.name);
+    if (options.sharedPart) {
+      toolkit.newSharedPart(options.firm, options.sharedPart);
     } else if (options.all) {
       toolkit.newSharedPartsAll(options.firm);
     }
@@ -252,6 +236,26 @@ program
       options.sharedPart,
       options.handle
     );
+  });
+
+// Add all shared parts
+program
+  .command("add-all-shared-parts")
+  .description(
+    "Add all shared parts to all reconciliations (based on the config file of shared parts and the handles assigned there to each reconciliation)"
+  )
+  .requiredOption(
+    "-f, --firm <firm-id>",
+    "Specify the firm to be used",
+    firmIdDefault
+  )
+  .option("--yes", "Skip the prompt confirmation (optional)")
+  .action((options) => {
+    if (!options.yes) {
+      promptConfirmation();
+    }
+    checkDefaultFirm(options.firm);
+    toolkit.addAllSharedPartsToAllReconciliation(options.firm);
   });
 
 // Remove shared part to reconciliation
@@ -331,13 +335,13 @@ program
     "By default, the reconciled status will be set as true. Add this option to set it as false (optional)"
   )
   .option(
-    "-t, --test-name <testName>",
+    "-t, --test <test-name>",
     "Establish the name of the test. It should have no white-spaces (e.g. test_name)(optional)"
   )
   .action((options) => {
     reconciledStatus = options.unreconciled ? false : true;
-    testName = options.testName ? options.testName : "test_name";
-    liquidTests.testGenerator(options.url);
+    let testName = options.test ? options.test : "test_name";
+    liquidTests.testGenerator(options.url, testName);
   });
 
 // Authorize APP
@@ -429,40 +433,24 @@ program
     "Specify the firm to be used",
     firmIdDefault
   )
-  .option("-n, --name <name>", "Fetch the shared part ID by name")
+  .option("-s, --shared-part <name>", "Fetch the shared part ID by name")
   .option("-a, --all", "Fetch the ID for every shared part")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    checkUniqueOption(["name", "all"], options);
+    checkUniqueOption(["sharedPart", "all"], options);
     if (!options.yes) {
       promptConfirmation();
     }
     checkDefaultFirm(options.firm);
-    if (options.name) {
-      toolkit.updateTemplateID(options.firm, "shared_parts", options.name);
+    if (options.sharedPart) {
+      toolkit.updateTemplateID(
+        options.firm,
+        "shared_parts",
+        options.sharedPart
+      );
     } else if (options.all) {
       toolkit.getAllTemplatesId(options.firm, "shared_parts");
     }
-  });
-
-// Add all shared parts
-program
-  .command("add-all-shared-parts")
-  .description(
-    "Add all shared parts to all reconciliations (based on the config file of shared parts)"
-  )
-  .requiredOption(
-    "-f, --firm <firm-id>",
-    "Specify the firm to be used",
-    firmIdDefault
-  )
-  .option("--yes", "Skip the prompt confirmation (optional)")
-  .action((options) => {
-    if (!options.yes) {
-      promptConfirmation();
-    }
-    checkDefaultFirm(options.firm);
-    toolkit.addAllSharedPartsToAllReconciliation(options.firm);
   });
 
 // Update the CLI

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -404,19 +404,7 @@ program
   .option("-a, --all", "Fetch the ID for every reconciliation")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    // Check that only one of the options it's selected
-    const uniqueParameters = ["handle", "all"];
-    const optionsToCheck = Object.keys(options).filter((element) => {
-      if (uniqueParameters.includes(element)) {
-        return true;
-      }
-    });
-    if (optionsToCheck.length !== 1) {
-      console.log(
-        "Get reconciliation id: you have to use either --handle or --all option"
-      );
-      process.exit(1);
-    }
+    checkUniqueOption(["handle", "all"], options);
     if (!options.yes) {
       promptConfirmation();
     }
@@ -445,19 +433,7 @@ program
   .option("-a, --all", "Fetch the ID for every shared part")
   .option("--yes", "Skip the prompt confirmation (optional)")
   .action((options) => {
-    // Check that only one of the options it's selected
-    const uniqueParameters = ["name", "all"];
-    const optionsToCheck = Object.keys(options).filter((element) => {
-      if (uniqueParameters.includes(element)) {
-        return true;
-      }
-    });
-    if (optionsToCheck.length !== 1) {
-      console.log(
-        "Get reconciliation id: you have to use either --handle or --all option"
-      );
-      process.exit(1);
-    }
+    checkUniqueOption(["name", "all"], options);
     if (!options.yes) {
       promptConfirmation();
     }

--- a/fs_utils.js
+++ b/fs_utils.js
@@ -97,7 +97,7 @@ async function createLiquidFile(relativePath, fileName, textContent) {
 
 function writeConfig(relativePath, config) {
   emptyCallback = () => {};
-  fs.writeFile(
+  fs.writeFileSync(
     `${relativePath}/config.json`,
     JSON.stringify(config, null, 2),
     emptyCallback
@@ -110,7 +110,15 @@ function readConfig(relativePath) {
   return config;
 }
 
+function createConfigIfMissing(relativePath) {
+  if (!fs.existsSync(`${relativePath}/config.json`)) {
+    const config = { id: {} };
+    writeConfig(relativePath, config);
+  }
+}
+
 // Get an array with all the reconciliations or all shared parts
+// Based on the existence of a config.json file
 function getTemplatePaths(relativePath) {
   if (
     relativePath !== "shared_parts" &&
@@ -136,6 +144,20 @@ function getTemplatePaths(relativePath) {
   return templatesArray;
 }
 
+// Get the handle/name of a reconciliation/shared part by it's ID
+function findHandleByID(type, id) {
+  if (type !== "shared_parts" && type !== "reconciliation_texts") {
+    throw "type should be shared_parts or reconciliation_texts";
+  }
+  let templatesArray = getTemplatePaths(type);
+  for (let templatePath of templatesArray) {
+    let config = readConfig(templatePath);
+    if (config.id[firmId] === id) {
+      return config.handle || config.name;
+    }
+  }
+}
+
 // Get an array with all the shared parts (name) used in a specific reconciliation (handle)
 function getSharedParts(handle) {
   const reconciliationConfig = readConfig(`reconciliation_texts/${handle}`);
@@ -156,13 +178,15 @@ function getSharedParts(handle) {
 }
 
 module.exports = {
+  readConfig,
   writeConfig,
+  createConfigIfMissing,
   createTemplateFiles,
   createLiquidTestFiles,
   createLiquidFile,
   createFolder,
   createFolders,
-  readConfig,
   getTemplatePaths,
+  findHandleByID,
   getSharedParts,
 };

--- a/fs_utils.js
+++ b/fs_utils.js
@@ -87,7 +87,7 @@ async function createTemplateFiles(relativePath, textMain, textParts) {
 
 async function createLiquidFile(relativePath, fileName, textContent) {
   const emptyCallback = () => {};
-  fs.writeFile(
+  fs.writeFileSync(
     `${relativePath}/${fileName}.liquid`,
     textContent,
     emptyCallback
@@ -111,6 +111,8 @@ function readConfig(relativePath) {
 }
 
 function createConfigIfMissing(relativePath) {
+  createFolder(relativePath);
+
   if (!fs.existsSync(`${relativePath}/config.json`)) {
     const config = { id: {} };
     writeConfig(relativePath, config);
@@ -145,7 +147,7 @@ function getTemplatePaths(relativePath) {
 }
 
 // Get the handle/name of a reconciliation/shared part by it's ID
-function findHandleByID(type, id) {
+function findHandleByID(firmId, type, id) {
   if (type !== "shared_parts" && type !== "reconciliation_texts") {
     throw "type should be shared_parts or reconciliation_texts";
   }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ const isWsl = require("is-wsl");
 const commandExistsSync = require("command-exists").sync;
 
 const RECONCILIATION_FIELDS_TO_SYNC = [
-  "id",
   "handle",
   "name_en",
   "name_fr",
@@ -63,7 +62,7 @@ function errorHandler(error) {
   }
 }
 
-function storeImportedReconciliation(reconciliationText) {
+function storeImportedReconciliation(firmId, reconciliationText) {
   const handle = reconciliationText.handle || reconciliationText.id;
 
   if (!reconciliationText.text) {
@@ -110,6 +109,9 @@ function storeImportedReconciliation(reconciliationText) {
 
   const configContent = {
     ...attributes,
+    id: {
+      [firmId]: reconciliationText.id,
+    },
     text: "main.liquid",
     text_parts: configTextParts,
     test: `tests/${handle}_liquid_test.yml`,
@@ -122,7 +124,7 @@ async function importExistingReconciliationByHandle(firmId, handle) {
   if (!reconciliationText) {
     throw `${handle} wasn't found`;
   }
-  storeImportedReconciliation(reconciliationText);
+  storeImportedReconciliation(firmId, reconciliationText);
 }
 
 async function importExistingReconciliationById(firmId, reconciliationId) {
@@ -133,7 +135,7 @@ async function importExistingReconciliationById(firmId, reconciliationId) {
   if (!reconciliationText) {
     throw `${reconciliationId} wasn't found`;
   }
-  storeImportedReconciliation(reconciliationText);
+  storeImportedReconciliation(firmId, reconciliationText);
 }
 
 // Import all reconciliations
@@ -147,9 +149,56 @@ async function importExistingReconciliations(firmId, page = 1) {
     return;
   }
   reconciliationsArray.forEach(async (reconciliation) => {
-    storeImportedReconciliation(reconciliation);
+    storeImportedReconciliation(firmId, reconciliation);
   });
   importExistingReconciliations(firmId, page + 1);
+}
+
+// Look for the template in Silverfin with the handle/name and get it's ID
+// Type has to be either "reconciliation_texts" or "shared_parts"
+async function updateTemplateID(firmId, type, handle) {
+  let relativePath;
+  let templateText;
+  if (type === "reconciliation_texts") {
+    relativePath = `./reconciliation_texts/${handle}`;
+    templateText = await SF.findReconciliationText(firmId, handle);
+  }
+  if (type === "shared_parts") {
+    relativePath = `./shared_parts/${handle}`;
+    templateText = await SF.findSharedPart(firmId, handle);
+  }
+  if (!templateText) {
+    console.log(`${handle} wasn't found`);
+    return;
+  }
+  const configPath = `${relativePath}/config.json`;
+  if (!fs.existsSync(configPath)) {
+    console.log(
+      `There is no config.json file for ${handle}. You need to import or create it first.`
+    );
+    return;
+  }
+  const config = fsUtils.readConfig(relativePath);
+  if (typeof config.id !== "object") {
+    config.id = {};
+  }
+  config.id[firmId] = templateText.id;
+  fsUtils.writeConfig(relativePath, config);
+  console.log(`${handle}: ID updated`);
+}
+
+// For all existing reconciliations in the repository, find their IDs
+async function getAllTemplatesId(firmId, type) {
+  try {
+    let templatesArray = fsUtils.getTemplatePaths(type); // shared_parts or reconciliation_texts
+    for (configPath of templatesArray) {
+      let configTemplate = fsUtils.readConfig(configPath);
+      let handle = configTemplate.handle || configTemplate.name;
+      await updateTemplateID(firmId, type, handle);
+    }
+  } catch (error) {
+    errorHandler(error);
+  }
 }
 
 function constructReconciliationText(handle) {
@@ -183,8 +232,8 @@ async function persistReconciliationText(firmId, handle) {
     const relativePath = `./reconciliation_texts/${handle}`;
     const config = fsUtils.readConfig(relativePath);
     let reconciliationTextId;
-    if (config && config.id) {
-      reconciliationTextId = config.id;
+    if (config && config.id[firmId]) {
+      reconciliationTextId = config.id[firmId];
       console.log("Loaded from config");
     } else {
       reconciliationTextId = {
@@ -221,11 +270,37 @@ async function importExistingSharedPartById(firmId, id) {
     sharedPart.data.text
   );
 
-  let config = {
-    id: sharedPart.data.id,
+  // Adjust ID and find reconciliation handle
+  let used_in = [];
+  for (reconciliation of sharedPart.data.used_in) {
+    // Search in repository
+    let reconHandle = fsUtils.findHandleByID(
+      "reconciliation_texts",
+      reconciliation.id
+    );
+    if (reconHandle) {
+      reconciliation.handle = reconHandle;
+      // Search through the API
+    } else {
+      let reconciliationText = await SF.findReconciliationTextById(
+        firmId,
+        reconciliation.id
+      );
+      if (reconciliationText) {
+        reconciliation.handle = reconciliationText.handle;
+      }
+    }
+    reconId = reconciliation.id;
+    reconciliation.id = {};
+    reconciliation.id[firmId] = reconId;
+    used_in.push(reconciliation);
+  }
+
+  const config = {
+    id: { [firmId]: sharedPart.data.id },
     name: sharedPart.data.name,
     text: "main.liquid",
-    used_in: sharedPart.data.used_in,
+    used_in: used_in,
   };
 
   fsUtils.writeConfig(relativePath, config);
@@ -236,7 +311,7 @@ async function importExistingSharedPartByName(firmId, name) {
   if (!sharedPartByName) {
     throw `Shared part with name ${name} wasn't found.`;
   }
-  importExistingSharedPartById(firmId, sharedPartByName.id);
+  await importExistingSharedPartById(firmId, sharedPartByName.id);
 }
 
 async function importExistingSharedParts(firmId, page = 1) {
@@ -251,7 +326,7 @@ async function importExistingSharedParts(firmId, page = 1) {
   sharedParts.forEach(async (sharedPart) => {
     await importExistingSharedPartById(firmId, sharedPart.id);
   });
-  importExistingSharedParts(firmId, page + 1);
+  await importExistingSharedParts(firmId, page + 1);
 }
 
 async function persistSharedPart(firmId, name) {
@@ -263,7 +338,7 @@ async function persistSharedPart(firmId, name) {
       `${relativePath}/${name}.liquid`,
       "utf-8"
     );
-    SF.updateSharedPart(firmId, config.id, {
+    SF.updateSharedPart(firmId, config.id[firmId], {
       ...attributes,
       version_comment: "Testing Cli",
     });
@@ -272,38 +347,41 @@ async function persistSharedPart(firmId, name) {
   }
 }
 
-/* This will overwrite existing shared parts in reconcilation's config file */
-/* Look in each shared part if it is used in the provided reconciliation */
-function refreshSharedPartsUsed(handle) {
+async function newSharedPart(firmId, name) {
   try {
-    const relativePath = `./reconciliation_texts/${handle}`;
-    const configReconciliation = fsUtils.readConfig(relativePath);
-    configReconciliation.shared_parts = [];
-    fs.readdir(`./shared_parts`, (error, allSharedParts) => {
-      if (error) throw error;
-      for (sharedPartDir of allSharedParts) {
-        let sharedPartPath = `./shared_parts/${sharedPartDir}`;
-        let dir = fs.statSync(sharedPartPath, () => {});
-        if (dir.isDirectory()) {
-          let configSharedPart = fsUtils.readConfig(sharedPartPath);
-          configSharedPart.used_in.find((template, index) => {
-            if (template.id == configReconciliation.id) {
-              configReconciliation.shared_parts.push({
-                id: configSharedPart.id,
-                name: sharedPartDir,
-              });
-              console.log(
-                `Shared part ${sharedPartDir} used in reconciliation ${handle}:`
-              );
-              return true;
-            }
-          });
-        }
-      }
-      fsUtils.writeConfig(relativePath, configReconciliation);
+    const existingSharedPart = await SF.findSharedPart(firmId, name);
+    if (existingSharedPart) {
+      console.log(`Shared part ${name} already exists. Skip it's creation`);
+      return;
+    }
+    const relativePath = `./shared_parts/${name}`;
+    fsUtils.createConfigIfMissing(relativePath);
+    const config = fsUtils.readConfig(relativePath);
+    const attributes = {};
+    attributes.text = fs.readFileSync(
+      `${relativePath}/${name}.liquid`,
+      "utf-8"
+    );
+    attributes.name = name;
+    const response = await SF.createSharedPart(firmId, {
+      ...attributes,
+      version_comment: "Creating shared part with the Cli",
     });
+    // Store new firm id
+    if (response && response.status == 201) {
+      config.id[firmId] = response.data.id;
+      fsUtils.writeConfig(relativePath, config);
+    }
   } catch (error) {
     errorHandler(error);
+  }
+}
+
+async function newSharedPartsAll(firmId) {
+  const sharedPartsArray = fsUtils.getTemplatePaths("shared_parts");
+  for (sharedPartPath of sharedPartsArray) {
+    const sharedPartName = sharedPartPath.split("/")[2];
+    await newSharedPart(firmId, sharedPartName);
   }
 }
 
@@ -314,48 +392,93 @@ async function addSharedPartToReconciliation(
 ) {
   try {
     const relativePathReconciliation = `./reconciliation_texts/${reconciliationHandle}`;
-    const configReconciliation = fsUtils.readConfig(relativePathReconciliation);
+    const configReconciliation = await fsUtils.readConfig(
+      relativePathReconciliation
+    );
     configReconciliation.shared_parts = configReconciliation.shared_parts || [];
 
     const relativePathSharedPart = `./shared_parts/${sharedPartHandle}`;
-    const configSharedPart = fsUtils.readConfig(relativePathSharedPart);
+    const configSharedPart = await fsUtils.readConfig(relativePathSharedPart);
+
+    if (!configReconciliation.id[firmId] || !configSharedPart.id[firmId]) {
+      console.log(
+        `ID missing for reconciliation and/or shared part (${reconciliationHandle} & ${sharedPartHandle})`
+      );
+      return;
+    }
 
     const response = await SF.addSharedPart(
       firmId,
-      configSharedPart.id,
-      configReconciliation.id
+      configSharedPart.id[firmId],
+      configReconciliation.id[firmId]
     );
 
     if (response.status === 201) {
       console.log(
         `Shared part "${sharedPartHandle}" added to "${reconciliationHandle}" reconciliation text.`
       );
-    }
 
-    const sharedPartIndex = configReconciliation.shared_parts.findIndex(
-      (sharedPart) => sharedPart.id === configSharedPart.id
-    );
+      const sharedPartIndex = configReconciliation.shared_parts.findIndex(
+        (sharedPart) => sharedPartHandle === sharedPart.name
+      );
+      const reconciliationIndex = configSharedPart.used_in.findIndex(
+        (reconciliationText) =>
+          reconciliationHandle === reconciliationText.handle
+      );
 
-    if (sharedPartIndex === -1) {
-      configReconciliation.shared_parts.push({
-        id: configSharedPart.id,
-        name: sharedPartHandle,
-      });
-      fsUtils.writeConfig(relativePathReconciliation, configReconciliation);
-    }
-    const reconciliationIndex = configSharedPart.used_in.findIndex(
-      (reconciliationText) => reconciliationText.id === configReconciliation.id
-    );
+      // Not stored yet
+      if (sharedPartIndex === -1) {
+        configReconciliation.shared_parts.push({
+          id: { [firmId]: configSharedPart.id[firmId] },
+          name: sharedPartHandle,
+        });
+      }
+      // Previously stored
+      if (sharedPartIndex !== -1) {
+        configReconciliation.shared_parts[sharedPartIndex].id[firmId] =
+          configSharedPart.id[firmId];
+      }
 
-    if (reconciliationIndex === -1) {
-      configSharedPart.used_in.push({
-        id: configReconciliation.id,
-        type: "reconciliation",
-      });
+      // Not stored yet
+      if (reconciliationIndex === -1) {
+        configSharedPart.used_in.push({
+          id: { [firmId]: configReconciliation.id[firmId] },
+          type: "reconciliation",
+          handle: reconciliationHandle,
+        });
+      }
+      // Previously stored
+      if (reconciliationIndex !== -1) {
+        configSharedPart.used_in[reconciliationIndex].id[firmId] =
+          configReconciliation.id[firmId];
+      }
+
+      // Save Configs
       fsUtils.writeConfig(relativePathSharedPart, configSharedPart);
+      fsUtils.writeConfig(relativePathReconciliation, configReconciliation);
     }
   } catch (error) {
     errorHandler(error);
+  }
+}
+
+// Loop through all shared parts (config files)
+// Try to add the shared part to each reconciliation listed in 'used_in'
+async function addAllSharedPartsToAllReconciliation(firmId) {
+  const sharedPartsArray = fsUtils.getTemplatePaths("shared_parts");
+  for (sharedPartPath of sharedPartsArray) {
+    let configSharedPart = fsUtils.readConfig(sharedPartPath);
+    for (reconciliation of configSharedPart.used_in) {
+      if (reconciliation.handle) {
+        if (fs.existsSync(`./reconciliation_texts/${reconciliation.handle}`)) {
+          await addSharedPartToReconciliation(
+            firmId,
+            configSharedPart.name,
+            reconciliation.handle
+          );
+        }
+      }
+    }
   }
 }
 
@@ -374,8 +497,8 @@ async function removeSharedPartFromReconciliation(
 
     const response = await SF.removeSharedPart(
       firmId,
-      configSharedPart.id,
-      configReconciliation.id
+      configSharedPart.id[firmId],
+      configReconciliation.id[firmId]
     );
     if (response.status === 200) {
       console.log(
@@ -384,7 +507,7 @@ async function removeSharedPartFromReconciliation(
     }
 
     const sharedPartIndex = configReconciliation.shared_parts.findIndex(
-      (sharedPart) => sharedPart.id === configSharedPart.id
+      (sharedPart) => sharedPart.id[firmId] === configSharedPart.id[firmId]
     );
     if (sharedPartIndex !== -1) {
       configReconciliation.shared_parts.splice(sharedPartIndex, 1);
@@ -392,7 +515,8 @@ async function removeSharedPartFromReconciliation(
     }
 
     const reconciliationIndex = configSharedPart.used_in.findIndex(
-      (reconciliationText) => reconciliationText.id === configReconciliation.id
+      (reconciliationText) =>
+        reconciliationText.id[firmId] === configReconciliation.id[firmId]
     );
     if (reconciliationIndex !== -1) {
       configSharedPart.used_in.splice(reconciliationIndex, 1);
@@ -753,15 +877,19 @@ module.exports = {
   importExistingSharedPartByName,
   importExistingSharedParts,
   persistSharedPart,
-  refreshSharedPartsUsed,
+  newSharedPart,
+  newSharedPartsAll,
   addSharedPartToReconciliation,
   removeSharedPartFromReconciliation,
+  addAllSharedPartsToAllReconciliation,
   runTests,
   runTestsWithOutput,
   getHTML,
   resolveHTMLPath,
   checkAllTestsErrorsPresent,
   authorize,
+  updateTemplateID,
+  getAllTemplatesId,
   uncaughtErrors,
   setDefaultFirmID,
   getDefaultFirmID,

--- a/index.js
+++ b/index.js
@@ -63,7 +63,14 @@ function errorHandler(error) {
 }
 
 function storeImportedReconciliation(firmId, reconciliationText) {
-  const handle = reconciliationText.handle || reconciliationText.id;
+  if (!reconciliationText.handle) {
+    console.log(
+      `Reconciliation has no handle, add a handle before importing it. Skipped`
+    );
+    return;
+  }
+
+  const handle = reconciliationText.handle;
 
   if (!reconciliationText.text) {
     console.log(

--- a/index.js
+++ b/index.js
@@ -208,6 +208,7 @@ async function getAllTemplatesId(firmId, type) {
   }
 }
 
+// Recreate reconciliation (main and text parts)
 function constructReconciliationText(handle) {
   const relativePath = `./reconciliation_texts/${handle}`;
   const config = fsUtils.readConfig(relativePath);
@@ -392,6 +393,7 @@ async function newSharedPartsAll(firmId) {
   }
 }
 
+// Link a shared part to a reconciliation
 async function addSharedPartToReconciliation(
   firmId,
   sharedPartHandle,
@@ -402,7 +404,6 @@ async function addSharedPartToReconciliation(
     const configReconciliation = await fsUtils.readConfig(
       relativePathReconciliation
     );
-    configReconciliation.shared_parts = configReconciliation.shared_parts || [];
 
     const relativePathSharedPart = `./shared_parts/${sharedPartHandle}`;
     const configSharedPart = await fsUtils.readConfig(relativePathSharedPart);
@@ -425,26 +426,10 @@ async function addSharedPartToReconciliation(
         `Shared part "${sharedPartHandle}" added to "${reconciliationHandle}" reconciliation text.`
       );
 
-      const sharedPartIndex = configReconciliation.shared_parts.findIndex(
-        (sharedPart) => sharedPartHandle === sharedPart.name
-      );
       const reconciliationIndex = configSharedPart.used_in.findIndex(
         (reconciliationText) =>
           reconciliationHandle === reconciliationText.handle
       );
-
-      // Not stored yet
-      if (sharedPartIndex === -1) {
-        configReconciliation.shared_parts.push({
-          id: { [firmId]: configSharedPart.id[firmId] },
-          name: sharedPartHandle,
-        });
-      }
-      // Previously stored
-      if (sharedPartIndex !== -1) {
-        configReconciliation.shared_parts[sharedPartIndex].id[firmId] =
-          configSharedPart.id[firmId];
-      }
 
       // Not stored yet
       if (reconciliationIndex === -1) {
@@ -497,7 +482,6 @@ async function removeSharedPartFromReconciliation(
   try {
     const relativePathReconciliation = `./reconciliation_texts/${reconciliationHandle}`;
     const configReconciliation = fsUtils.readConfig(relativePathReconciliation);
-    configReconciliation.shared_parts = configReconciliation.shared_parts || [];
 
     const relativePathSharedPart = `./shared_parts/${sharedPartHandle}`;
     const configSharedPart = fsUtils.readConfig(relativePathSharedPart);
@@ -511,14 +495,6 @@ async function removeSharedPartFromReconciliation(
       console.log(
         `Shared part "${sharedPartHandle}" removed from "${reconciliationHandle}" reconciliation text.`
       );
-    }
-
-    const sharedPartIndex = configReconciliation.shared_parts.findIndex(
-      (sharedPart) => sharedPart.id[firmId] === configSharedPart.id[firmId]
-    );
-    if (sharedPartIndex !== -1) {
-      configReconciliation.shared_parts.splice(sharedPartIndex, 1);
-      fsUtils.writeConfig(relativePathReconciliation, configReconciliation);
     }
 
     const reconciliationIndex = configSharedPart.used_in.findIndex(

--- a/index.js
+++ b/index.js
@@ -239,18 +239,11 @@ async function persistReconciliationText(firmId, handle) {
   try {
     const relativePath = `./reconciliation_texts/${handle}`;
     const config = fsUtils.readConfig(relativePath);
-    let reconciliationTextId;
-    if (config && config.id[firmId]) {
-      reconciliationTextId = config.id[firmId];
-      console.log("Loaded from config");
-    } else {
-      reconciliationTextId = {
-        ...(await SF.findReconciliationText(firmId, handle)),
-      }.id;
+    if (!config || !config.id[firmId]) {
+      console.log(`Reconciliation ${handle}: ID is missing. Aborted`);
+      process.exit(1);
     }
-    if (!reconciliationTextId) {
-      throw "Reconciliation not found";
-    }
+    let reconciliationTextId = (reconciliationTextId = config.id[firmId]);
     SF.updateReconciliationText(firmId, reconciliationTextId, {
       ...constructReconciliationText(handle),
       version_comment: "Update published using the API",
@@ -341,6 +334,10 @@ async function persistSharedPart(firmId, name) {
   try {
     const relativePath = `./shared_parts/${name}`;
     const config = fsUtils.readConfig(relativePath);
+    if (!config || !config.id[firmId]) {
+      console.log(`Shared part ${name}: ID is missing. Aborted`);
+      process.exit(1);
+    }
     const attributes = {};
     attributes.text = fs.readFileSync(
       `${relativePath}/${name}.liquid`,

--- a/index.js
+++ b/index.js
@@ -249,6 +249,11 @@ async function persistReconciliationText(firmId, handle) {
     const config = fsUtils.readConfig(relativePath);
     if (!config || !config.id[firmId]) {
       console.log(`Reconciliation ${handle}: ID is missing. Aborted`);
+      console.log(
+        `Try running: ${chalk.bold(
+          `silverfin get-reconciliation-id --handle ${handle}`
+        )} or ${chalk.bold(`silverfin get-reconciliation-id --all`)}`
+      );
       process.exit(1);
     }
     let reconciliationTextId = config.id[firmId];
@@ -371,6 +376,11 @@ async function persistSharedPart(firmId, name) {
     const config = fsUtils.readConfig(relativePath);
     if (!config || !config.id[firmId]) {
       console.log(`Shared part ${name}: ID is missing. Aborted`);
+      console.log(
+        `Try running: ${chalk.bold(
+          `silverfin get-shared-part-id --shared-part ${name}`
+        )} or ${chalk.bold(`silverfin get-shared-part-id --all`)}`
+      );
       process.exit(1);
     }
     const attributes = {};

--- a/liquid_test_generator/generator.js
+++ b/liquid_test_generator/generator.js
@@ -3,7 +3,7 @@ const { config } = require("../api/auth");
 const Utils = require("./utils");
 
 // MainProcess
-async function testGenerator(url) {
+async function testGenerator(url, testName) {
   // Liquid Test Object
   const liquidTestObject = Utils.createBaseLiquidTest(testName);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf_toolkit",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",

--- a/stats_utils.js
+++ b/stats_utils.js
@@ -135,7 +135,6 @@ async function generateStatsOverview(sinceDate) {
     fs.mkdirSync("stats");
   }
   if (!fs.existsSync(csvPath)) {
-    console.log(process.cwd());
     fs.writeFileSync(csvPath, constRowHeader, (err) => {
       console.log(err);
     });


### PR DESCRIPTION
The idea is to be able to store multiple firm ids for reconciliations and shared parts. That way we would be able to interact with different environments with the same set of templates (e.g. development, staging, production)

Currently, `config.json` looks like:
```
{
  "id": 123456,
  ...
}
```
From now on, we will store it like this:
```
{ 
  "id": {
    "123": 123456,    // firmId : templateId
  },
 ...
}
``` 
Also, in the `config.json` of the shared part we added two extra parameters (`type` and `handle`) about each template that uses the shared part:
```
{
  ...
  "used_in": [
    { 
      "id":  {
        "123: 123456
      },
      "type": "reconciliation",
      "handle": "reconciliation_handle",
} 
```

It will allow us to search this templates in environments where don't have the corresponding ID yet

This can be considered a breaking change since, when implemented, the existing reference of the id won't be useful anymore. 
Any call to `update-reconciliation` or `update-shared-part` command will fail (showing a message in the terminal indicating the missing ID)

We should run the commands `get-reconciliation-id --all` and `get-shared-part-id --all` in existing repositories to update every template and have the new syntax

One advantage of this new flow is that allow us to replicate all reconciliations, shared parts and relationships between them from one environment into another one. The only missing part now is the command to `create-reconciliation` (which we can already add since the required API endpoint has been implemented)

Edit 02/02/2023: Considering that this will be a breaking change, and some functionality won't be working until you update the ids, I think that we could raise a message when the user is trying to use a command and still have the old syntax, to suggest to update the ids before continuing ? I'll look into this and how can be done

