### PR TITLE
ReconciliationTexts: create commands

### DIFF
--- a/api/sf_api.js
+++ b/api/sf_api.js
@@ -187,6 +187,31 @@ async function responseErrorHandler(
   throw error;
 }
 
+async function createReconciliationText(
+  firmId,
+  attributes,
+  refreshToken = true
+) {
+  setAxiosDefaults(firmId);
+  try {
+    const response = await axios.post(`reconciliations`, attributes);
+    responseSuccessHandler(response);
+    return response;
+  } catch (error) {
+    const callbackParameters = {
+      attributes: attributes,
+      refreshToken: false,
+    };
+    const response = await responseErrorHandler(
+      error,
+      refreshToken,
+      createReconciliationText,
+      callbackParameters
+    );
+    return response;
+  }
+}
+
 async function fetchReconciliationTexts(firmId, page = 1, refreshToken = true) {
   setAxiosDefaults(firmId);
   try {
@@ -530,7 +555,7 @@ async function addSharedPart(
       firmId,
       error,
       refreshToken,
-      updateSharedPart,
+      addSharedPart,
       callbackParameters
     );
     return response;
@@ -561,7 +586,7 @@ async function removeSharedPart(
       firmId,
       error,
       refreshToken,
-      updateSharedPart,
+      removeSharedPart,
       callbackParameters
     );
     return response;
@@ -853,6 +878,7 @@ async function getAccountDetails(
 
 module.exports = {
   authorizeApp,
+  createReconciliationText,
   fetchReconciliationTexts,
   updateReconciliationText,
   findReconciliationText,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -137,6 +137,33 @@ program
     toolkit.persistReconciliationText(options.firm, options.handle);
   });
 
+// Create new reconciliation
+program
+  .command("create-reconciliation")
+  .description("Create a new reconciliation text")
+  .requiredOption(
+    "-f, --firm <firm-id>",
+    "Specify the firm to be used",
+    firmIdDefault
+  )
+  .option(
+    "-h, --handle <handle>",
+    "Specify the handle of the reconciliation text to be created"
+  )
+  .option(
+    "-a, --all",
+    "Try to create all the reconciliation texts stored in the repository"
+  )
+  .action((options) => {
+    checkUniqueOption(["handle", "all"], options);
+    checkDefaultFirm(options.firm);
+    if (options.handle) {
+      toolkit.newReconciliation(options.firm, options.handle);
+    } else if (options.all) {
+      toolkit.newReconciliationsAll(options.firm);
+    }
+  });
+
 // Import shared parts
 program
   .command("import-shared-part")
@@ -193,7 +220,10 @@ program
     "Specify the firm to be used",
     firmIdDefault
   )
-  .option("-s, --shared-part <name>", "Specify the shared part to be used")
+  .option(
+    "-s, --shared-part <name>",
+    "Specify the name of the shared part to be created"
+  )
   .option(
     "-a, --all",
     "Try to create all the shared parts stored in the repository"

--- a/fs_utils.js
+++ b/fs_utils.js
@@ -110,11 +110,18 @@ function readConfig(relativePath) {
   return config;
 }
 
-function createConfigIfMissing(relativePath) {
+function createConfigIfMissing(relativePath, templateType = undefined) {
   createFolder(relativePath);
 
   if (!fs.existsSync(`${relativePath}/config.json`)) {
     const config = { id: {} };
+    if (templateType == "reconciliation_text") {
+      config.text = "main.liquid";
+      config.text_parts = {};
+      config.auto_hide_formula = "";
+      config.text_configuration = null;
+      config.virtual_account_number = "";
+    }
     writeConfig(relativePath, config);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf_toolkit",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

New functions and commands to create one/all reconciliations text/s

`silverfin create-reconciliation --handle <handle>`
`silverfin create-reconciliation --all`

- If there is no `main.liquid`, we create an empty one
- If there is no `config.json`, we create an empty one. We set the handle as the name since it is required to create the reconciliation.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [x] Version updated (if needed)
- [ ] Documentation updated (if needed)
