### PR TITLE
Fix bugs when importing templates in UK

### DIFF
--- a/fs_utils.js
+++ b/fs_utils.js
@@ -2,8 +2,12 @@ const fs = require("fs");
 const path = require("path");
 
 function createFolder(path) {
-  if (!fs.existsSync(path)) {
-    fs.mkdirSync(path);
+  try {
+    if (!fs.existsSync(path)) {
+      fs.mkdirSync(path);
+    }
+  } catch (error) {
+    console.log(error);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function storeImportedReconciliation(firmId, reconciliationText) {
   const configContent = {
     ...attributes,
     id: {
-      ...existingConfig.id,
+      ...existingConfig?.id,
       [firmId]: reconciliationText.id,
     },
     text: "main.liquid",
@@ -333,16 +333,13 @@ async function importExistingSharedPartById(firmId, id) {
     throw `Shared part ${id} wasn't found.`;
   }
 
-  const relativePath = `./shared_parts/${sharedPart.data.name}`;
+  const sanitizedName = sharedPart.data.name.replace("/", "");
+  const relativePath = `./shared_parts/${sanitizedName}`;
 
   fsUtils.createFolder(`./shared_parts`);
   fsUtils.createFolder(relativePath);
 
-  fsUtils.createLiquidFile(
-    relativePath,
-    sharedPart.data.name,
-    sharedPart.data.text
-  );
+  fsUtils.createLiquidFile(relativePath, sanitizedName, sharedPart.data.text);
 
   let existingConfig;
 
@@ -399,7 +396,7 @@ async function importExistingSharedPartById(firmId, id) {
 
   const config = {
     id: { ...existingConfig.id, [firmId]: sharedPart.data.id },
-    name: sharedPart.data.name,
+    name: sanitizedName,
     text: "main.liquid",
     used_in: used_in,
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf_toolkit",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Command line tool for Silverfin template development",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

* Fix reconciliation import error occurring when a config exists without an existing id property
* Fix shared part import error when name contains a '/'

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [ ] README updated (if needed)
- [ ] Version updated (if needed)
- [ ] Documentation updated (if needed)
